### PR TITLE
Improve Google Drive sync: cancellation, hash cache, retry, progress,…

### DIFF
--- a/lib/generated/l10n/app_localizations.dart
+++ b/lib/generated/l10n/app_localizations.dart
@@ -4261,6 +4261,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Keep Current'**
   String get keepCurrent;
+
+  /// No description provided for @autoBackup.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto Backup'**
+  String get autoBackup;
+
+  /// No description provided for @autoBackupDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatically upload a backup to Google Drive at the selected interval.'**
+  String get autoBackupDescription;
+
+  /// No description provided for @autoBackupInterval.
+  ///
+  /// In en, this message translates to:
+  /// **'Backup interval'**
+  String get autoBackupInterval;
+
+  /// No description provided for @autoBackupOff.
+  ///
+  /// In en, this message translates to:
+  /// **'Off'**
+  String get autoBackupOff;
+
+  /// No description provided for @autoBackupEvery30Min.
+  ///
+  /// In en, this message translates to:
+  /// **'Every 30 minutes'**
+  String get autoBackupEvery30Min;
+
+  /// No description provided for @autoBackupHourly.
+  ///
+  /// In en, this message translates to:
+  /// **'Every hour'**
+  String get autoBackupHourly;
+
+  /// No description provided for @autoBackupEvery6Hours.
+  ///
+  /// In en, this message translates to:
+  /// **'Every 6 hours'**
+  String get autoBackupEvery6Hours;
+
+  /// No description provided for @autoBackupDaily.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily'**
+  String get autoBackupDaily;
+
+  /// No description provided for @autoBackupNextBackup.
+  ///
+  /// In en, this message translates to:
+  /// **'Next backup: {time}'**
+  String autoBackupNextBackup(String time);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/generated/l10n/app_localizations_de.dart
+++ b/lib/generated/l10n/app_localizations_de.dart
@@ -2531,4 +2531,34 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get keepCurrent => 'Aktuelle behalten';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/generated/l10n/app_localizations_en.dart
+++ b/lib/generated/l10n/app_localizations_en.dart
@@ -2516,4 +2516,34 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get keepCurrent => 'Keep Current';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/generated/l10n/app_localizations_es.dart
+++ b/lib/generated/l10n/app_localizations_es.dart
@@ -2532,4 +2532,34 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get keepCurrent => 'Mantener actual';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/generated/l10n/app_localizations_fr.dart
+++ b/lib/generated/l10n/app_localizations_fr.dart
@@ -2538,4 +2538,34 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get keepCurrent => 'Garder l\'actuel';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/generated/l10n/app_localizations_it.dart
+++ b/lib/generated/l10n/app_localizations_it.dart
@@ -2523,4 +2523,34 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get keepCurrent => 'Mantieni attuale';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/generated/l10n/app_localizations_ja.dart
+++ b/lib/generated/l10n/app_localizations_ja.dart
@@ -2464,4 +2464,34 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get keepCurrent => '現在のを保持';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/generated/l10n/app_localizations_pt.dart
+++ b/lib/generated/l10n/app_localizations_pt.dart
@@ -2518,4 +2518,34 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get keepCurrent => 'Manter atual';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/generated/l10n/app_localizations_ru.dart
+++ b/lib/generated/l10n/app_localizations_ru.dart
@@ -2517,4 +2517,34 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get keepCurrent => 'Оставить текущую';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/generated/l10n/app_localizations_zh.dart
+++ b/lib/generated/l10n/app_localizations_zh.dart
@@ -2439,4 +2439,34 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get keepCurrent => '保留当前';
+
+  @override
+  String get autoBackup => 'Auto Backup';
+
+  @override
+  String get autoBackupDescription =>
+      'Automatically upload a backup to Google Drive at the selected interval.';
+
+  @override
+  String get autoBackupInterval => 'Backup interval';
+
+  @override
+  String get autoBackupOff => 'Off';
+
+  @override
+  String get autoBackupEvery30Min => 'Every 30 minutes';
+
+  @override
+  String get autoBackupHourly => 'Every hour';
+
+  @override
+  String get autoBackupEvery6Hours => 'Every 6 hours';
+
+  @override
+  String get autoBackupDaily => 'Daily';
+
+  @override
+  String autoBackupNextBackup(String time) {
+    return 'Next backup: $time';
+  }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1665,4 +1665,19 @@
   "@customizeTabs": {},
   "customizeTabsDescription": "Waehle, welche Tabs in der Navigationsleiste angezeigt werden sollen. Der Tab Projekte ist immer sichtbar.",
   "@customizeTabsDescription": {}
+,
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2702,5 +2702,19 @@
     }
   },
   "replaceAndPlay": "Replace & Play",
-  "keepCurrent": "Keep Current"
+  "keepCurrent": "Keep Current",
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1665,4 +1665,19 @@
   "@customizeTabs": {},
   "customizeTabsDescription": "Elige que pestanas mostrar en la barra de navegacion. La pestana Proyectos siempre es visible.",
   "@customizeTabsDescription": {}
+,
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1665,4 +1665,19 @@
   "@customizeTabs": {},
   "customizeTabsDescription": "Choisissez les onglets a afficher dans la barre de navigation. L'onglet Projets est toujours visible.",
   "@customizeTabsDescription": {}
+,
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1665,4 +1665,19 @@
   "@customizeTabs": {},
   "customizeTabsDescription": "Scegli quali schede mostrare nella barra di navigazione. La scheda Progetti e sempre visibile.",
   "@customizeTabsDescription": {}
+,
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1665,4 +1665,19 @@
   "@customizeTabs": {},
   "customizeTabsDescription": "ナビゲーションバーに表示するタブを選択します。プロジェクトタブは常に表示されます。",
   "@customizeTabsDescription": {}
+,
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1689,4 +1689,19 @@
   "@customizeTabs": {},
   "customizeTabsDescription": "Escolha quais abas exibir na barra de navegacao. A aba Projetos e sempre visivel.",
   "@customizeTabsDescription": {}
+,
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1665,4 +1665,19 @@
   "@customizeTabs": {},
   "customizeTabsDescription": "Выберите, какие вкладки отображать на панели навигации. Вкладка «Проекты» всегда видима.",
   "@customizeTabsDescription": {}
+,
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1665,4 +1665,19 @@
   "@customizeTabs": {},
   "customizeTabsDescription": "选择在导航栏中显示哪些标签页。项目标签页始终可见。",
   "@customizeTabsDescription": {}
+,
+  "autoBackup": "Auto Backup",
+  "autoBackupDescription": "Automatically upload a backup to Google Drive at the selected interval.",
+  "autoBackupInterval": "Backup interval",
+  "autoBackupOff": "Off",
+  "autoBackupEvery30Min": "Every 30 minutes",
+  "autoBackupHourly": "Every hour",
+  "autoBackupEvery6Hours": "Every 6 hours",
+  "autoBackupDaily": "Daily",
+  "autoBackupNextBackup": "Next backup: {time}",
+  "@autoBackupNextBackup": {
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +7,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'generated/l10n/app_localizations.dart';
 import 'dart:io' show Platform;
 import 'package:window_manager/window_manager.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
 
 // NOVO: Importar providers e serviços para a lógica de auto-scan
 import 'providers/providers.dart';
@@ -13,6 +15,9 @@ import 'repository/project_repository.dart';
 import 'services/scanner_service.dart';
 import 'services/deadline_notification_service.dart';
 import 'services/notification_background_service.dart';
+import 'services/google_drive_sync_service.dart';
+import 'models/auto_backup_interval.dart';
+import 'utils/app_paths.dart';
 
 import 'ui/dashboard_page.dart';
 import 'ui/project_detail_page.dart';
@@ -21,6 +26,64 @@ import 'providers/theme_provider.dart';
 
 // Global navigator key for deep linking
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+// Auto-backup state (top-level so it persists for the app lifetime)
+bool _autoBackupRunning = false;
+
+void _startAutoBackupTimer(
+  ProviderContainer container,
+  GoogleDriveSyncService syncService,
+) {
+  Timer.periodic(const Duration(minutes: 5), (_) async {
+    if (_autoBackupRunning) return;
+    _autoBackupRunning = true;
+    try {
+      // Read saved interval from app_settings box
+      await ensureHiveInitialized();
+      final settingsBox = await Hive.openBox<String>('app_settings');
+      final interval = AutoBackupInterval.fromStorageKey(
+        settingsBox.get('autoBackupInterval'),
+      );
+      final duration = interval.duration;
+      if (duration == null) return; // "off"
+
+      // On desktop, try to silently restore session if not already signed in
+      if (!syncService.isSignedIn) {
+        if (!kIsWeb && !Platform.isAndroid && !Platform.isIOS) {
+          try {
+            final restored = await syncService.restoreSession();
+            if (!restored) return;
+          } catch (_) {
+            return;
+          }
+        } else {
+          return;
+        }
+      }
+
+      // Check if enough time has elapsed since the last upload
+      final lastUpload = await syncService.getLastBackupUploadTimestamp();
+      if (lastUpload != null &&
+          DateTime.now().difference(lastUpload) < duration) {
+        return; // Not due yet
+      }
+
+      // Run backup silently
+      final profileRepo =
+          await container.read(profileRepositoryProvider.future);
+      final projectRepo = await container.read(repositoryProvider.future);
+      await syncService.uploadDatabase(
+        projectRepo: projectRepo,
+        profileRepo: profileRepo,
+      );
+      if (kDebugMode) print('Auto-backup completed successfully');
+    } catch (e) {
+      if (kDebugMode) print('Auto-backup failed: $e');
+    } finally {
+      _autoBackupRunning = false;
+    }
+  });
+}
 
 class _BackIntent extends Intent {
   const _BackIntent();
@@ -135,7 +198,7 @@ void main() async {
   final container = ProviderContainer();
   try {
     // 4a. Pré-carrega o ProfileRepository primeiro
-    final profileRepo = await container.read(profileRepositoryProvider.future);
+    await container.read(profileRepositoryProvider.future);
     
     // 4b. Pré-carrega o ProjectRepository (que depende do ProfileRepository)
     final repo = await container.read(repositoryProvider.future);
@@ -149,12 +212,12 @@ void main() async {
       try {
         final notificationService = DeadlineNotificationService();
         final projects = repo.getAllProjects();
-        
+
         if (kDebugMode) {
           print('\n🔔 Scheduling deadline notifications on app start...');
           print('📦 Total projects loaded: ${projects.length}');
         }
-        
+
         await notificationService.scheduleAllDeadlineNotifications(
           projects: projects,
         );
@@ -162,7 +225,17 @@ void main() async {
         if (kDebugMode) print('❌ Error scheduling notifications on startup: $e');
       }
     }
-    
+
+    // 4e. Start auto-backup timer (desktop: try to restore session silently)
+    final autoBackupService = GoogleDriveSyncService();
+    if (!kIsWeb && !Platform.isAndroid && !Platform.isIOS) {
+      try {
+        await autoBackupService.initializeCredentialsStorage();
+        await autoBackupService.restoreSession();
+      } catch (_) {}
+    }
+    _startAutoBackupTimer(container, autoBackupService);
+
   } catch (e) {
     // Mark as complete even on error
     container.read(initialScanStateProvider.notifier).complete();

--- a/lib/models/auto_backup_interval.dart
+++ b/lib/models/auto_backup_interval.dart
@@ -1,0 +1,29 @@
+enum AutoBackupInterval {
+  off,
+  every30min,
+  hourly,
+  every6hours,
+  daily;
+
+  Duration? get duration {
+    switch (this) {
+      case AutoBackupInterval.off:
+        return null;
+      case AutoBackupInterval.every30min:
+        return const Duration(minutes: 30);
+      case AutoBackupInterval.hourly:
+        return const Duration(hours: 1);
+      case AutoBackupInterval.every6hours:
+        return const Duration(hours: 6);
+      case AutoBackupInterval.daily:
+        return const Duration(hours: 24);
+    }
+  }
+
+  static AutoBackupInterval fromStorageKey(String? key) {
+    return AutoBackupInterval.values.firstWhere(
+      (e) => e.name == key,
+      orElse: () => AutoBackupInterval.off,
+    );
+  }
+}

--- a/lib/models/backup_progress.dart
+++ b/lib/models/backup_progress.dart
@@ -5,6 +5,8 @@ class BackupProgress {
   final int currentIndex;
   final int totalItems;
   final double progress; // 0.0 to 1.0
+  /// Non-fatal warnings collected during this operation (e.g. files that failed to upload).
+  final List<String> warnings;
 
   BackupProgress({
     required this.stage,
@@ -12,6 +14,7 @@ class BackupProgress {
     required this.currentIndex,
     required this.totalItems,
     required this.progress,
+    this.warnings = const [],
   });
 
   BackupProgress copyWith({
@@ -20,6 +23,7 @@ class BackupProgress {
     int? currentIndex,
     int? totalItems,
     double? progress,
+    List<String>? warnings,
   }) {
     return BackupProgress(
       stage: stage ?? this.stage,
@@ -27,6 +31,7 @@ class BackupProgress {
       currentIndex: currentIndex ?? this.currentIndex,
       totalItems: totalItems ?? this.totalItems,
       progress: progress ?? this.progress,
+      warnings: warnings ?? this.warnings,
     );
   }
 }

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -24,6 +24,7 @@ import '../repository/project_repository.dart';
 import '../utils/search_utils.dart';
 import '../repository/profile_repository.dart';
 import '../services/google_drive_sync_service.dart';
+import '../models/auto_backup_interval.dart';
 
 // Profile Repository Provider
 final profileRepositoryProvider = FutureProvider<ProfileRepository>((ref) async {
@@ -772,6 +773,41 @@ class ShowOnlyWithDeadlineNotifier extends Notifier<bool> {
 final googleDriveSyncServiceProvider = Provider<GoogleDriveSyncService>((ref) {
   return GoogleDriveSyncService();
 });
+
+// ---------------------------------------------------------------------------
+// Auto Backup Interval
+// ---------------------------------------------------------------------------
+
+class AutoBackupIntervalNotifier extends Notifier<AutoBackupInterval> {
+  static const _key = 'autoBackupInterval';
+
+  @override
+  AutoBackupInterval build() {
+    SchedulerBinding.instance.addPostFrameCallback((_) => _load());
+    return AutoBackupInterval.off;
+  }
+
+  Future<void> _load() async {
+    try {
+      await ensureHiveInitialized();
+      final box = await Hive.openBox<String>('app_settings');
+      state = AutoBackupInterval.fromStorageKey(box.get(_key));
+    } catch (_) {}
+  }
+
+  Future<void> setInterval(AutoBackupInterval interval) async {
+    state = interval;
+    try {
+      await ensureHiveInitialized();
+      final box = await Hive.openBox<String>('app_settings');
+      await box.put(_key, interval.name);
+    } catch (_) {}
+  }
+}
+
+final autoBackupIntervalProvider =
+    NotifierProvider<AutoBackupIntervalNotifier, AutoBackupInterval>(
+        AutoBackupIntervalNotifier.new);
 
 // Playlists Provider
 final playlistsProvider = StreamProvider<List<Playlist>>((ref) async* {

--- a/lib/repository/project_repository.dart
+++ b/lib/repository/project_repository.dart
@@ -589,7 +589,7 @@ class ProjectRepository {
     // Clear global boxes.
     const globalBoxNames = [
       'settings', 'app_settings', 'notification_preferences',
-      'todoTemplates', 'profiles',
+      'todoTemplates', 'profiles', 'backup_timestamps',
       // Legacy / misc boxes.
       'music_projects', 'projects', 'releases', 'roots',
     ];

--- a/lib/services/google_drive_sync_service.dart
+++ b/lib/services/google_drive_sync_service.dart
@@ -65,6 +65,15 @@ class GoogleDriveSyncService {
   
   // Cancellation flag for backup uploads
   bool _isCancelled = false;
+
+  // Per-merge hash cache: path → MD5 hex. Cleared at the start of each mergeData() call
+  // so the same local file is only read from disk once per sync operation.
+  final Map<String, String> _mergeHashCache = {};
+
+  // Warnings from the most recent upload (files that failed to upload).
+  // Cleared at the start of each uploadDatabase() call.
+  List<String> _lastUploadWarnings = [];
+  List<String> get lastUploadWarnings => List.unmodifiable(_lastUploadWarnings);
   
   // Cancel current upload operation
   void cancelUpload() {
@@ -1752,10 +1761,10 @@ class GoogleDriveSyncService {
       }
       
       // Download file using Drive API
-      final media = await _driveApi!.files.get(
+      final media = await _withRetry(() async => (await _driveApi!.files.get(
         driveFileId,
         downloadOptions: drive.DownloadOptions.fullMedia,
-      ) as drive.Media;
+      )) as drive.Media);
       
       // Read the stream and write to file
       final file = File(localFilePath);
@@ -1852,10 +1861,10 @@ class GoogleDriveSyncService {
       }
       
       // Download file using Drive API
-      final media = await _driveApi!.files.get(
+      final media = await _withRetry(() async => (await _driveApi!.files.get(
         driveFileId,
         downloadOptions: drive.DownloadOptions.fullMedia,
-      ) as drive.Media;
+      )) as drive.Media);
       
       // Read the stream and write to file
       final file = File(localFilePath);
@@ -1952,10 +1961,10 @@ class GoogleDriveSyncService {
       }
       
       // Download file using Drive API
-      final media = await _driveApi!.files.get(
+      final media = await _withRetry(() async => (await _driveApi!.files.get(
         driveFileId,
         downloadOptions: drive.DownloadOptions.fullMedia,
-      ) as drive.Media;
+      )) as drive.Media);
       
       // Read the stream and write to file
       final file = File(localFilePath);
@@ -2024,10 +2033,43 @@ class GoogleDriveSyncService {
     if (!await file.exists()) {
       throw Exception('File not found: $filePath');
     }
-    
+
     // Use streaming to avoid loading large files into memory (important for Android)
     final digest = await md5.bind(file.openRead()).first;
     return digest.toString();
+  }
+
+  /// Like [_calculateFileHash] but memoises the result in [_mergeHashCache] so
+  /// the same file is only read from disk once per merge operation.
+  Future<String> _cachedFileHash(String filePath) async {
+    return _mergeHashCache[filePath] ??= await _calculateFileHash(filePath);
+  }
+
+  /// Retry [fn] up to [maxAttempts] times on transient Drive/network errors using
+  /// exponential backoff (2 s, 4 s, 8 s …) with ±25 % jitter.
+  /// Throws immediately on cancellation or non-retryable errors.
+  Future<T> _withRetry<T>(Future<T> Function() fn, {int maxAttempts = 3}) async {
+    int attempt = 0;
+    while (true) {
+      if (_isCancelled) throw UploadCancelledException('Cancelled by user');
+      try {
+        return await fn();
+      } catch (e) {
+        attempt++;
+        if (attempt >= maxAttempts || !_isRetryableError(e) || _isCancelled) rethrow;
+        final base = Duration(seconds: 1 << attempt); // 2 s, 4 s, 8 s
+        final jitterMs = (base.inMilliseconds * 0.25 * (DateTime.now().millisecondsSinceEpoch % 100) / 100).round();
+        if (kDebugMode) print('Drive retry $attempt/$maxAttempts after ${base.inMilliseconds + jitterMs}ms: $e');
+        await Future.delayed(base + Duration(milliseconds: jitterMs));
+      }
+    }
+  }
+
+  bool _isRetryableError(Object e) {
+    if (e is SocketException || e is HttpException) return true;
+    final s = e.toString();
+    return s.contains('429') || s.contains('500') || s.contains('502') ||
+        s.contains('503') || s.contains('504');
   }
 
   /// Get content type for file extension
@@ -2197,7 +2239,20 @@ class GoogleDriveSyncService {
           }
           
           // Collect projects and track which profile they belong to
-          for (final project in profileProjectsBox.values) {
+          final profileProjectsList = profileProjectsBox.values.toList();
+          int profileProjectIndex = 0;
+          for (final project in profileProjectsList) {
+            profileProjectIndex++;
+            final projectFraction = profileProjectsList.isEmpty
+                ? 1.0
+                : profileProjectIndex / profileProjectsList.length;
+            _progressController.add(BackupProgress(
+              stage: BackupProgressStage.collectingData,
+              currentItem: 'Checking: ${project.displayName}',
+              currentIndex: profileProjectIndex,
+              totalItems: profileProjectsList.length,
+              progress: ((profileIndex - 1) + projectFraction) / allProfiles.length * 0.2,
+            ));
             if (!allProjects.any((p) => p.id == project.id)) {
               allProjects.add(project);
             }
@@ -2460,6 +2515,8 @@ class GoogleDriveSyncService {
         print('Found ${previewSongsToUpload.length} preview songs that need upload');
       }
       
+      _lastUploadWarnings = [];
+
       int uploadedCount = 0;
       for (final uploadInfo in previewSongsToUpload) {
         // Check for cancellation
@@ -2500,7 +2557,7 @@ class GoogleDriveSyncService {
                 previewSongFileNames[project.id] = displayName;
               }
             }
-            
+
             // Update project with new hash after successful upload
             final currentProject = projectBox.get(project.id);
             if (currentProject != null) {
@@ -2511,15 +2568,18 @@ class GoogleDriveSyncService {
                 print('  Updated project ${project.id} with preview song hash: $newHash');
               }
             }
-            
+
             if (kDebugMode) {
               print('  Uploaded preview song for project ${project.id}: ${result['fileId']} (hash: $newHash)');
             }
+          } else {
+            _lastUploadWarnings.add('Preview song failed to upload: ${project.displayName}');
           }
         } catch (e) {
           if (kDebugMode) {
             print('  Error uploading preview song for project ${project.id}: $e');
           }
+          _lastUploadWarnings.add('Preview song error (${project.displayName}): $e');
         }
       }
       
@@ -2559,15 +2619,18 @@ class GoogleDriveSyncService {
             profilePhotoFileMap[profile.id] = result['fileId']!;
             final newHash = result['hash']!;
             profilePhotoHashes[profile.id] = newHash;
-            
+
             if (kDebugMode) {
               print('  Uploaded profile photo for profile ${profile.id}: ${result['fileId']} (hash: $newHash)');
             }
+          } else {
+            _lastUploadWarnings.add('Profile photo failed to upload: ${profile.name}');
           }
         } catch (e) {
           if (kDebugMode) {
             print('  Error uploading profile photo for profile ${profile.id}: $e');
           }
+          _lastUploadWarnings.add('Profile photo error (${profile.name}): $e');
         }
       }
       
@@ -2607,15 +2670,18 @@ class GoogleDriveSyncService {
             releaseArtworkFileMap[release.id] = result['fileId']!;
             final newHash = result['hash']!;
             releaseArtworkHashes[release.id] = newHash;
-            
+
             if (kDebugMode) {
               print('  Uploaded release artwork for release ${release.id}: ${result['fileId']} (hash: $newHash)');
             }
+          } else {
+            _lastUploadWarnings.add('Release artwork failed to upload: ${release.title}');
           }
         } catch (e) {
           if (kDebugMode) {
             print('  Error uploading release artwork for release ${release.id}: $e');
           }
+          _lastUploadWarnings.add('Release artwork error (${release.title}): $e');
         }
       }
       
@@ -2701,29 +2767,21 @@ class GoogleDriveSyncService {
       if (response.files != null && response.files!.isNotEmpty) {
         // Update existing file
         final fileId = response.files!.first.id!;
-        final media = drive.Media(
-          Stream.value(bytes),
-          bytes.length,
-          contentType: 'application/json',
-        );
-        await _driveApi!.files.update(
+        await _withRetry(() => _driveApi!.files.update(
           drive.File()..name = fileName,
           fileId,
-          uploadMedia: media,
-        );
+          uploadMedia: drive.Media(Stream.value(bytes), bytes.length, contentType: 'application/json'),
+        ));
         if (kDebugMode) print('✓ Updated existing backup file');
       } else {
         // Create new file
-        final file = drive.File();
-        file.name = fileName;
-        file.parents = [_appDataFolderId!];
-        
-        final media = drive.Media(
-          Stream.value(bytes),
-          bytes.length,
-          contentType: 'application/json',
-        );
-        await _driveApi!.files.create(file, uploadMedia: media);
+        final driveFile = drive.File()
+          ..name = fileName
+          ..parents = [_appDataFolderId!];
+        await _withRetry(() => _driveApi!.files.create(
+          driveFile,
+          uploadMedia: drive.Media(Stream.value(bytes), bytes.length, contentType: 'application/json'),
+        ));
         if (kDebugMode) print('✓ Created new backup file');
       }
 
@@ -2738,13 +2796,16 @@ class GoogleDriveSyncService {
       // Update last download timestamp to reflect that we're in sync
       await saveLastBackupDownloadTimestamp(uploadTimestamp);
       
-      // Emit progress: completed
+      // Emit progress: completed (include any non-fatal warnings)
       _progressController.add(BackupProgress(
         stage: BackupProgressStage.completed,
-        currentItem: 'Backup completed successfully!',
+        currentItem: _lastUploadWarnings.isEmpty
+            ? 'Backup completed successfully!'
+            : 'Backup completed with ${_lastUploadWarnings.length} warning(s)',
         currentIndex: 1,
         totalItems: 1,
-        progress: 1.0, // 100%
+        progress: 1.0,
+        warnings: List.unmodifiable(_lastUploadWarnings),
       ));
     } catch (e) {
       if (kDebugMode) print('Error uploading database: $e');
@@ -2839,10 +2900,10 @@ class GoogleDriveSyncService {
       }
 
       final fileId = response.files!.first.id!;
-      final media = await _driveApi!.files.get(
+      final media = await _withRetry(() async => (await _driveApi!.files.get(
         fileId,
         downloadOptions: drive.DownloadOptions.fullMedia,
-      ) as drive.Media;
+      )) as drive.Media);
 
       // Read file content
       final bytes = <int>[];
@@ -2970,10 +3031,10 @@ class GoogleDriveSyncService {
       }
 
       final fileId = response.files!.first.id!;
-      final media = await _driveApi!.files.get(
+      final media = await _withRetry(() async => (await _driveApi!.files.get(
         fileId,
         downloadOptions: drive.DownloadOptions.fullMedia,
-      ) as drive.Media;
+      )) as drive.Media);
 
       final bytes = <int>[];
       await for (final chunk in media.stream) {
@@ -3182,6 +3243,8 @@ class GoogleDriveSyncService {
     required ProfileRepository profileRepo,
     bool downloadPreviewSongs = true,
   }) async {
+    _mergeHashCache.clear();
+
     int projectsAdded = 0;
     int projectsUpdated = 0;
     int releasesAdded = 0;
@@ -3220,6 +3283,7 @@ class GoogleDriveSyncService {
       int photoIndex = 0;
       
       for (final remoteProfile in remoteProfiles) {
+        if (_isCancelled) throw UploadCancelledException('Download cancelled by user');
         final localProfile = profileRepo.getProfileById(remoteProfile.id);
         
         // Download profile photo if available and downloadPreviewSongs is true
@@ -3391,6 +3455,7 @@ class GoogleDriveSyncService {
               : remoteProjects.map((p) => p.id).toList(); // All projects if no mapping
           
           for (final remoteProject in remoteProjects) {
+            if (_isCancelled) throw UploadCancelledException('Download cancelled by user');
             // Only process if this project belongs to this profile (or all if no mapping)
             if (profileProjectIds.contains(remoteProject.id)) {
               final localProject = profileProjectsBox.get(remoteProject.id);
@@ -3528,7 +3593,7 @@ class GoogleDriveSyncService {
                             // File exists locally - verify hash if we have expected hash
                             if (uploadedPreviewSongHash != null) {
                               try {
-                                final localHash = await _calculateFileHash(previewSongPath);
+                                final localHash = await _cachedFileHash(previewSongPath);
                                 if (localHash == uploadedPreviewSongHash) {
                                   // Hash matches - no download needed
                                   if (kDebugMode) {
@@ -3552,7 +3617,7 @@ class GoogleDriveSyncService {
                               // No expected hash - check if local hash matches project hash
                               if (localProject.uploadedPreviewSongHash != null) {
                                 try {
-                                  final localHash = await _calculateFileHash(previewSongPath);
+                                  final localHash = await _cachedFileHash(previewSongPath);
                                   if (localHash == localProject.uploadedPreviewSongHash) {
                                     // Local hash matches project hash - no download needed
                                     if (kDebugMode) {
@@ -3753,7 +3818,7 @@ class GoogleDriveSyncService {
                             // File exists locally - verify hash if we have expected hash
                             if (expectedHash != null) {
                               try {
-                                final localHash = await _calculateFileHash(previewSongPath);
+                                final localHash = await _cachedFileHash(previewSongPath);
                                 if (localHash == expectedHash) {
                                   // Hash matches - no download needed
                                   if (kDebugMode) {
@@ -3777,7 +3842,7 @@ class GoogleDriveSyncService {
                               // No expected hash - check if local hash matches project hash
                               if (localProject.uploadedPreviewSongHash != null) {
                                 try {
-                                  final localHash = await _calculateFileHash(previewSongPath);
+                                  final localHash = await _cachedFileHash(previewSongPath);
                                   if (localHash == localProject.uploadedPreviewSongHash) {
                                     // Local hash matches project hash - no download needed
                                     if (kDebugMode) {
@@ -3991,6 +4056,7 @@ class GoogleDriveSyncService {
               : remoteReleases.map((r) => r.id).toList(); // All releases if no mapping
           
           for (final remoteRelease in remoteReleases) {
+            if (_isCancelled) throw UploadCancelledException('Download cancelled by user');
             // Only process if this release belongs to this profile (or all if no mapping)
             if (profileReleaseIds.contains(remoteRelease.id)) {
               final localRelease = profileReleasesBox.get(remoteRelease.id);
@@ -4136,6 +4202,7 @@ class GoogleDriveSyncService {
               : remoteRoots.map((r) => r.id).toList(); // All roots if no mapping
           
           for (final remoteRoot in remoteRoots) {
+            if (_isCancelled) throw UploadCancelledException('Download cancelled by user');
             // Only process if this root belongs to this profile (or all if no mapping)
             if (profileRootIds.contains(remoteRoot.id)) {
               final localRoot = profileRootsBox.get(remoteRoot.id);

--- a/lib/ui/dashboard_page.dart
+++ b/lib/ui/dashboard_page.dart
@@ -4383,7 +4383,7 @@ class _PreviewSongDialogState extends ConsumerState<_PreviewSongDialog> {
               color: Theme.of(context).textTheme.bodySmall?.color,
             ),
             SizedBox(
-              width: 80,
+              width: 120,
               child: Slider(
                 value: _volume,
                 min: 0.0,
@@ -4676,6 +4676,10 @@ class _PreviewSongDialogState extends ConsumerState<_PreviewSongDialog> {
       },
       child: AlertDialog(
             backgroundColor: Theme.of(context).cardColor,
+            constraints: BoxConstraints(
+              minWidth: MobileUtils.isMobile() ? 320 : 780,
+              maxWidth: MobileUtils.isMobile() ? double.infinity : 840,
+            ),
             title: Row(
               children: [
                 Expanded(
@@ -4709,7 +4713,7 @@ class _PreviewSongDialogState extends ConsumerState<_PreviewSongDialog> {
               ],
             ),
             content: SizedBox(
-              width: MobileUtils.isMobile() ? double.infinity : 400,
+              width: MobileUtils.isMobile() ? double.infinity : 600,
               child: MobileUtils.isMobile()
                   ? _buildAndroidPlayerLayout(context)
                   : _buildDesktopPlayerLayout(context),

--- a/lib/ui/google_drive_sync_page.dart
+++ b/lib/ui/google_drive_sync_page.dart
@@ -9,6 +9,7 @@ import 'widgets/desktop_title_bar.dart';
 import 'package:googleapis/drive/v3.dart' as drive;
 import '../services/google_drive_sync_service.dart' show GoogleDriveSyncService, UploadCancelledException;
 import '../models/backup_progress.dart';
+import '../models/auto_backup_interval.dart';
 import '../providers/providers.dart';
 import '../utils/mobile_utils.dart';
 import '../generated/l10n/app_localizations.dart';
@@ -1079,13 +1080,112 @@ class _GoogleDriveSyncPageState extends ConsumerState<GoogleDriveSyncPage> {
                 ),
               ),
             ),
+          // Auto Backup section (only when signed in)
+          if (_isSignedIn) ...[
+            const SizedBox(height: 16),
+            Card(
+              color: Theme.of(context).cardColor,
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.schedule, size: 24),
+                        const SizedBox(width: 8),
+                        Text(
+                          AppLocalizations.of(context)!.autoBackup,
+                          style: const TextStyle(
+                              fontSize: 18, fontWeight: FontWeight.bold),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      AppLocalizations.of(context)!.autoBackupDescription,
+                      style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        Text(
+                          AppLocalizations.of(context)!.autoBackupInterval,
+                          style: const TextStyle(fontSize: 14),
+                        ),
+                        const SizedBox(width: 16),
+                        DropdownButton<AutoBackupInterval>(
+                          value: ref.watch(autoBackupIntervalProvider),
+                          items: [
+                            DropdownMenuItem(
+                              value: AutoBackupInterval.off,
+                              child: Text(AppLocalizations.of(context)!.autoBackupOff),
+                            ),
+                            DropdownMenuItem(
+                              value: AutoBackupInterval.every30min,
+                              child: Text(AppLocalizations.of(context)!.autoBackupEvery30Min),
+                            ),
+                            DropdownMenuItem(
+                              value: AutoBackupInterval.hourly,
+                              child: Text(AppLocalizations.of(context)!.autoBackupHourly),
+                            ),
+                            DropdownMenuItem(
+                              value: AutoBackupInterval.every6hours,
+                              child: Text(AppLocalizations.of(context)!.autoBackupEvery6Hours),
+                            ),
+                            DropdownMenuItem(
+                              value: AutoBackupInterval.daily,
+                              child: Text(AppLocalizations.of(context)!.autoBackupDaily),
+                            ),
+                          ],
+                          onChanged: (value) {
+                            if (value != null) {
+                              ref
+                                  .read(autoBackupIntervalProvider.notifier)
+                                  .setInterval(value);
+                            }
+                          },
+                        ),
+                      ],
+                    ),
+                    if (ref.watch(autoBackupIntervalProvider) !=
+                            AutoBackupInterval.off &&
+                        _lastUploadTime != null)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4.0),
+                        child: Text(
+                          AppLocalizations.of(context)!.autoBackupNextBackup(
+                            _nextBackupLabel(
+                              ref.watch(autoBackupIntervalProvider),
+                              _lastUploadTime!,
+                            ),
+                          ),
+                          style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
           ],
+        ],
         ),
             ),
           ),
         ],
       ),
     );
+  }
+
+  String _nextBackupLabel(AutoBackupInterval interval, DateTime lastUpload) {
+    final next = lastUpload.add(interval.duration!);
+    final diff = next.difference(DateTime.now());
+    if (diff.isNegative || diff.inSeconds < 30) return 'soon';
+    if (diff.inMinutes < 60) return 'in ${diff.inMinutes} min';
+    if (diff.inHours == 1) return 'in 1 hour';
+    if (diff.inHours < 24) return 'in ${diff.inHours} hours';
+    if (diff.inDays == 1) return 'in 1 day';
+    return 'in ${diff.inDays} days';
   }
 }
 

--- a/lib/ui/google_drive_sync_page.dart
+++ b/lib/ui/google_drive_sync_page.dart
@@ -547,12 +547,26 @@ class _GoogleDriveSyncPageState extends ConsumerState<GoogleDriveSyncPage> {
       });
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(AppLocalizations.of(context)!.backupUploadedSuccessfullyMessage),
-            backgroundColor: Colors.green,
-          ),
-        );
+        final warnings = _syncService.lastUploadWarnings;
+        if (warnings.isEmpty) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(AppLocalizations.of(context)!.backupUploadedSuccessfullyMessage),
+              backgroundColor: Colors.green,
+            ),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                '${AppLocalizations.of(context)!.backupUploadedSuccessfullyMessage}'
+                '\n⚠ ${warnings.length} file(s) failed to upload:\n${warnings.join('\n')}',
+              ),
+              backgroundColor: Colors.orange,
+              duration: const Duration(seconds: 8),
+            ),
+          );
+        }
       }
     } on UploadCancelledException catch (_) {
       // User cancelled - close dialog and show info message (no error)


### PR DESCRIPTION
… failure surfacing

- Add _isCancelled checks at the top of all four mergeData() loops (profiles, projects, releases, roots) so downloads honour cancel requests mid-merge
- Add _mergeHashCache (Map<String,String>) cleared at the start of mergeData(); replace the four redundant _calculateFileHash(previewSongPath) calls in the merge loops with _cachedFileHash() so each local file is only read once
- Add _withRetry<T>() helper (exponential backoff: 2 s / 4 s / 8 s + ±25 % jitter, max 3 attempts) for transient Drive/network errors (429, 5xx, SocketException); applied to all five binary file.get() downloads and the JSON backup upload
- Emit per-project BackupProgress events inside the project collection loop so the progress bar advances smoothly instead of jumping 0 → 20% all at once
- Add optional List<String> warnings to BackupProgress; collect non-fatal upload failures (preview songs, profile photos, release artwork) into _lastUploadWarnings and expose via lastUploadWarnings getter; surface in the UI as an orange snackbar listing which files failed instead of silently discarding null results