### PR TITLE
Localize remaining hardcoded UI strings

### DIFF
--- a/lib/generated/l10n/app_localizations.dart
+++ b/lib/generated/l10n/app_localizations.dart
@@ -3938,6 +3938,102 @@ abstract class AppLocalizations {
   /// **'BPM'**
   String get sortByBpm;
 
+  /// No description provided for @sortNewestFirst.
+  ///
+  /// In en, this message translates to:
+  /// **'Newest first'**
+  String get sortNewestFirst;
+
+  /// No description provided for @sortOldestFirst.
+  ///
+  /// In en, this message translates to:
+  /// **'Oldest first'**
+  String get sortOldestFirst;
+
+  /// No description provided for @sortTitleAZ.
+  ///
+  /// In en, this message translates to:
+  /// **'Title A–Z'**
+  String get sortTitleAZ;
+
+  /// No description provided for @sortTitleZA.
+  ///
+  /// In en, this message translates to:
+  /// **'Title Z–A'**
+  String get sortTitleZA;
+
+  /// No description provided for @musicPlayerTab.
+  ///
+  /// In en, this message translates to:
+  /// **'Music Player'**
+  String get musicPlayerTab;
+
+  /// No description provided for @previewAudioChangedRefreshing.
+  ///
+  /// In en, this message translates to:
+  /// **'Preview audio changed on disk — refreshing waveform…'**
+  String get previewAudioChangedRefreshing;
+
+  /// No description provided for @audioFileChangedRefreshing.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio file changed on disk — refreshing waveform…'**
+  String get audioFileChangedRefreshing;
+
+  /// No description provided for @autoFitAllColumns.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto fit all columns'**
+  String get autoFitAllColumns;
+
+  /// No description provided for @uploadAutoDetectedPreviewSongs.
+  ///
+  /// In en, this message translates to:
+  /// **'Upload auto-detected preview songs'**
+  String get uploadAutoDetectedPreviewSongs;
+
+  /// No description provided for @uploadAutoDetectedPreviewSongsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Include songs found automatically by the scanner, not just ones you set manually.'**
+  String get uploadAutoDetectedPreviewSongsSubtitle;
+
+  /// No description provided for @monoGenerating.
+  ///
+  /// In en, this message translates to:
+  /// **'Mono...'**
+  String get monoGenerating;
+
+  /// No description provided for @errorHandlingDroppedFiles.
+  ///
+  /// In en, this message translates to:
+  /// **'Error handling dropped files: {error}'**
+  String errorHandlingDroppedFiles(String error);
+
+  /// No description provided for @resetOnboardingConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'This will restart the setup wizard. Continue?'**
+  String get resetOnboardingConfirm;
+
+  /// No description provided for @couldNotLaunchDaw.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not launch {daw}: {error}'**
+  String couldNotLaunchDaw(String daw, String error);
+
+  /// No description provided for @couldNotOpenLink.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open link.'**
+  String get couldNotOpenLink;
+
+  /// No description provided for @githubButtonLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'GitHub'**
+  String get githubButtonLabel;
+
   /// No description provided for @monoLabel.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/app_localizations_de.dart
+++ b/lib/generated/l10n/app_localizations_de.dart
@@ -2329,6 +2329,63 @@ class AppLocalizationsDe extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => 'Neueste zuerst';
+
+  @override
+  String get sortOldestFirst => 'Älteste zuerst';
+
+  @override
+  String get sortTitleAZ => 'Titel A–Z';
+
+  @override
+  String get sortTitleZA => 'Titel Z–A';
+
+  @override
+  String get musicPlayerTab => 'Musikplayer';
+
+  @override
+  String get previewAudioChangedRefreshing =>
+      'Vorschau-Audio auf der Festplatte geändert — Wellenform wird aktualisiert…';
+
+  @override
+  String get audioFileChangedRefreshing =>
+      'Audiodatei auf der Festplatte geändert — Wellenform wird aktualisiert…';
+
+  @override
+  String get autoFitAllColumns => 'Alle Spalten automatisch anpassen';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs =>
+      'Automatisch erkannte Vorschau-Songs hochladen';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      'Auch Songs einbeziehen, die automatisch vom Scanner gefunden wurden, nicht nur manuell festgelegte.';
+
+  @override
+  String get monoGenerating => 'Mono …';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return 'Fehler beim Verarbeiten der abgelegten Dateien: $error';
+  }
+
+  @override
+  String get resetOnboardingConfirm =>
+      'Dadurch wird der Einrichtungsassistent neu gestartet. Fortfahren?';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return '$daw konnte nicht gestartet werden: $error';
+  }
+
+  @override
+  String get couldNotOpenLink => 'Link konnte nicht geöffnet werden.';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => 'Mono';
 
   @override

--- a/lib/generated/l10n/app_localizations_en.dart
+++ b/lib/generated/l10n/app_localizations_en.dart
@@ -2315,6 +2315,63 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => 'Newest first';
+
+  @override
+  String get sortOldestFirst => 'Oldest first';
+
+  @override
+  String get sortTitleAZ => 'Title A–Z';
+
+  @override
+  String get sortTitleZA => 'Title Z–A';
+
+  @override
+  String get musicPlayerTab => 'Music Player';
+
+  @override
+  String get previewAudioChangedRefreshing =>
+      'Preview audio changed on disk — refreshing waveform…';
+
+  @override
+  String get audioFileChangedRefreshing =>
+      'Audio file changed on disk — refreshing waveform…';
+
+  @override
+  String get autoFitAllColumns => 'Auto fit all columns';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs =>
+      'Upload auto-detected preview songs';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      'Include songs found automatically by the scanner, not just ones you set manually.';
+
+  @override
+  String get monoGenerating => 'Mono...';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return 'Error handling dropped files: $error';
+  }
+
+  @override
+  String get resetOnboardingConfirm =>
+      'This will restart the setup wizard. Continue?';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return 'Could not launch $daw: $error';
+  }
+
+  @override
+  String get couldNotOpenLink => 'Could not open link.';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => 'Mono';
 
   @override

--- a/lib/generated/l10n/app_localizations_es.dart
+++ b/lib/generated/l10n/app_localizations_es.dart
@@ -2330,6 +2330,63 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => 'Más recientes primero';
+
+  @override
+  String get sortOldestFirst => 'Más antiguos primero';
+
+  @override
+  String get sortTitleAZ => 'Título A–Z';
+
+  @override
+  String get sortTitleZA => 'Título Z–A';
+
+  @override
+  String get musicPlayerTab => 'Reproductor de música';
+
+  @override
+  String get previewAudioChangedRefreshing =>
+      'El audio de vista previa cambió en el disco — actualizando la forma de onda…';
+
+  @override
+  String get audioFileChangedRefreshing =>
+      'El archivo de audio cambió en el disco — actualizando la forma de onda…';
+
+  @override
+  String get autoFitAllColumns => 'Ajustar automáticamente todas las columnas';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs =>
+      'Subir canciones de vista previa detectadas automáticamente';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      'Incluir canciones encontradas automáticamente por el escáner, no solo las que estableciste manualmente.';
+
+  @override
+  String get monoGenerating => 'Mono…';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return 'Error al procesar los archivos soltados: $error';
+  }
+
+  @override
+  String get resetOnboardingConfirm =>
+      'Esto reiniciará el asistente de configuración. ¿Continuar?';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return 'No se pudo iniciar $daw: $error';
+  }
+
+  @override
+  String get couldNotOpenLink => 'No se pudo abrir el enlace.';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => 'Mono';
 
   @override

--- a/lib/generated/l10n/app_localizations_fr.dart
+++ b/lib/generated/l10n/app_localizations_fr.dart
@@ -2339,6 +2339,63 @@ class AppLocalizationsFr extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => 'Plus récent d\'abord';
+
+  @override
+  String get sortOldestFirst => 'Plus ancien d\'abord';
+
+  @override
+  String get sortTitleAZ => 'Titre A–Z';
+
+  @override
+  String get sortTitleZA => 'Titre Z–A';
+
+  @override
+  String get musicPlayerTab => 'Lecteur de musique';
+
+  @override
+  String get previewAudioChangedRefreshing =>
+      'L\'audio d\'aperçu a changé sur le disque — actualisation de la forme d\'onde…';
+
+  @override
+  String get audioFileChangedRefreshing =>
+      'Le fichier audio a changé sur le disque — actualisation de la forme d\'onde…';
+
+  @override
+  String get autoFitAllColumns => 'Ajuster automatiquement toutes les colonnes';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs =>
+      'Envoyer les morceaux d\'aperçu détectés automatiquement';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      'Inclure les morceaux trouvés automatiquement par le scanner, pas seulement ceux définis manuellement.';
+
+  @override
+  String get monoGenerating => 'Mono…';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return 'Erreur lors du traitement des fichiers déposés : $error';
+  }
+
+  @override
+  String get resetOnboardingConfirm =>
+      'Cela relancera l\'assistant de configuration. Continuer ?';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return 'Impossible de lancer $daw : $error';
+  }
+
+  @override
+  String get couldNotOpenLink => 'Impossible d\'ouvrir le lien.';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => 'Mono';
 
   @override

--- a/lib/generated/l10n/app_localizations_it.dart
+++ b/lib/generated/l10n/app_localizations_it.dart
@@ -2323,6 +2323,63 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => 'Più recenti prima';
+
+  @override
+  String get sortOldestFirst => 'Più vecchi prima';
+
+  @override
+  String get sortTitleAZ => 'Titolo A–Z';
+
+  @override
+  String get sortTitleZA => 'Titolo Z–A';
+
+  @override
+  String get musicPlayerTab => 'Lettore musicale';
+
+  @override
+  String get previewAudioChangedRefreshing =>
+      'L\'audio di anteprima è cambiato su disco — aggiornamento della forma d\'onda…';
+
+  @override
+  String get audioFileChangedRefreshing =>
+      'Il file audio è cambiato su disco — aggiornamento della forma d\'onda…';
+
+  @override
+  String get autoFitAllColumns => 'Adatta automaticamente tutte le colonne';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs =>
+      'Carica brani di anteprima rilevati automaticamente';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      'Includi i brani trovati automaticamente dallo scanner, non solo quelli impostati manualmente.';
+
+  @override
+  String get monoGenerating => 'Mono…';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return 'Errore durante la gestione dei file trascinati: $error';
+  }
+
+  @override
+  String get resetOnboardingConfirm =>
+      'Questo riavvierà la procedura guidata di configurazione. Continuare?';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return 'Impossibile avviare $daw: $error';
+  }
+
+  @override
+  String get couldNotOpenLink => 'Impossibile aprire il link.';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => 'Mono';
 
   @override

--- a/lib/generated/l10n/app_localizations_ja.dart
+++ b/lib/generated/l10n/app_localizations_ja.dart
@@ -2272,6 +2272,59 @@ class AppLocalizationsJa extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => '新しい順';
+
+  @override
+  String get sortOldestFirst => '古い順';
+
+  @override
+  String get sortTitleAZ => 'タイトル A–Z';
+
+  @override
+  String get sortTitleZA => 'タイトル Z–A';
+
+  @override
+  String get musicPlayerTab => '音楽プレーヤー';
+
+  @override
+  String get previewAudioChangedRefreshing => 'プレビュー音声がディスク上で変更されました — 波形を更新中…';
+
+  @override
+  String get audioFileChangedRefreshing => '音声ファイルがディスク上で変更されました — 波形を更新中…';
+
+  @override
+  String get autoFitAllColumns => 'すべての列を自動調整';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs => '自動検出されたプレビュー曲をアップロード';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      '手動で設定した曲だけでなく、スキャナーが自動的に見つけた曲も含めます。';
+
+  @override
+  String get monoGenerating => 'モノラル…';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return 'ドロップされたファイルの処理エラー: $error';
+  }
+
+  @override
+  String get resetOnboardingConfirm => 'セットアップウィザードが再起動されます。続行しますか？';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return '$daw を起動できませんでした: $error';
+  }
+
+  @override
+  String get couldNotOpenLink => 'リンクを開けませんでした。';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => 'モノ';
 
   @override

--- a/lib/generated/l10n/app_localizations_pt.dart
+++ b/lib/generated/l10n/app_localizations_pt.dart
@@ -2316,6 +2316,63 @@ class AppLocalizationsPt extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => 'Mais recentes primeiro';
+
+  @override
+  String get sortOldestFirst => 'Mais antigos primeiro';
+
+  @override
+  String get sortTitleAZ => 'Título A–Z';
+
+  @override
+  String get sortTitleZA => 'Título Z–A';
+
+  @override
+  String get musicPlayerTab => 'Leitor de música';
+
+  @override
+  String get previewAudioChangedRefreshing =>
+      'O áudio de pré-visualização mudou no disco — atualizando a forma de onda…';
+
+  @override
+  String get audioFileChangedRefreshing =>
+      'O ficheiro de áudio mudou no disco — atualizando a forma de onda…';
+
+  @override
+  String get autoFitAllColumns => 'Ajustar automaticamente todas as colunas';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs =>
+      'Enviar músicas de pré-visualização detetadas automaticamente';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      'Incluir músicas encontradas automaticamente pelo scanner, não apenas as definidas manualmente.';
+
+  @override
+  String get monoGenerating => 'Mono…';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return 'Erro ao processar os ficheiros largados: $error';
+  }
+
+  @override
+  String get resetOnboardingConfirm =>
+      'Isto irá reiniciar o assistente de configuração. Continuar?';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return 'Não foi possível iniciar $daw: $error';
+  }
+
+  @override
+  String get couldNotOpenLink => 'Não foi possível abrir o link.';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => 'Mono';
 
   @override

--- a/lib/generated/l10n/app_localizations_ru.dart
+++ b/lib/generated/l10n/app_localizations_ru.dart
@@ -2316,6 +2316,63 @@ class AppLocalizationsRu extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => 'Сначала новые';
+
+  @override
+  String get sortOldestFirst => 'Сначала старые';
+
+  @override
+  String get sortTitleAZ => 'Название А–Я';
+
+  @override
+  String get sortTitleZA => 'Название Я–А';
+
+  @override
+  String get musicPlayerTab => 'Музыкальный плеер';
+
+  @override
+  String get previewAudioChangedRefreshing =>
+      'Аудио предпросмотра изменилось на диске — обновление формы волны…';
+
+  @override
+  String get audioFileChangedRefreshing =>
+      'Аудиофайл изменился на диске — обновление формы волны…';
+
+  @override
+  String get autoFitAllColumns => 'Автоподбор ширины всех столбцов';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs =>
+      'Загружать автоматически найденные превью-треки';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      'Включать треки, автоматически найденные сканером, а не только заданные вручную.';
+
+  @override
+  String get monoGenerating => 'Моно…';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return 'Ошибка обработки перетащенных файлов: $error';
+  }
+
+  @override
+  String get resetOnboardingConfirm =>
+      'Это перезапустит мастер настройки. Продолжить?';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return 'Не удалось запустить $daw: $error';
+  }
+
+  @override
+  String get couldNotOpenLink => 'Не удалось открыть ссылку.';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => 'Моно';
 
   @override

--- a/lib/generated/l10n/app_localizations_zh.dart
+++ b/lib/generated/l10n/app_localizations_zh.dart
@@ -2248,6 +2248,59 @@ class AppLocalizationsZh extends AppLocalizations {
   String get sortByBpm => 'BPM';
 
   @override
+  String get sortNewestFirst => '最新优先';
+
+  @override
+  String get sortOldestFirst => '最早优先';
+
+  @override
+  String get sortTitleAZ => '标题 A–Z';
+
+  @override
+  String get sortTitleZA => '标题 Z–A';
+
+  @override
+  String get musicPlayerTab => '音乐播放器';
+
+  @override
+  String get previewAudioChangedRefreshing => '预览音频在磁盘上已更改 — 正在刷新波形…';
+
+  @override
+  String get audioFileChangedRefreshing => '音频文件在磁盘上已更改 — 正在刷新波形…';
+
+  @override
+  String get autoFitAllColumns => '自动调整所有列';
+
+  @override
+  String get uploadAutoDetectedPreviewSongs => '上传自动检测到的预览歌曲';
+
+  @override
+  String get uploadAutoDetectedPreviewSongsSubtitle =>
+      '包括扫描器自动找到的歌曲，而不仅仅是手动设置的歌曲。';
+
+  @override
+  String get monoGenerating => '单声道…';
+
+  @override
+  String errorHandlingDroppedFiles(String error) {
+    return '处理拖放文件时出错：$error';
+  }
+
+  @override
+  String get resetOnboardingConfirm => '这将重新启动设置向导。是否继续？';
+
+  @override
+  String couldNotLaunchDaw(String daw, String error) {
+    return '无法启动 $daw：$error';
+  }
+
+  @override
+  String get couldNotOpenLink => '无法打开链接。';
+
+  @override
+  String get githubButtonLabel => 'GitHub';
+
+  @override
   String get monoLabel => '单声道';
 
   @override

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1512,6 +1512,33 @@
   "sortByPhase": "Phase",
   "sortByCreatedAt": "Hinzugefügt am",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "Neueste zuerst",
+  "sortOldestFirst": "Älteste zuerst",
+  "sortTitleAZ": "Titel A–Z",
+  "sortTitleZA": "Titel Z–A",
+  "musicPlayerTab": "Musikplayer",
+  "previewAudioChangedRefreshing": "Vorschau-Audio auf der Festplatte geändert — Wellenform wird aktualisiert…",
+  "audioFileChangedRefreshing": "Audiodatei auf der Festplatte geändert — Wellenform wird aktualisiert…",
+  "autoFitAllColumns": "Alle Spalten automatisch anpassen",
+  "uploadAutoDetectedPreviewSongs": "Automatisch erkannte Vorschau-Songs hochladen",
+  "uploadAutoDetectedPreviewSongsSubtitle": "Auch Songs einbeziehen, die automatisch vom Scanner gefunden wurden, nicht nur manuell festgelegte.",
+  "monoGenerating": "Mono …",
+  "errorHandlingDroppedFiles": "Fehler beim Verarbeiten der abgelegten Dateien: {error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "Dadurch wird der Einrichtungsassistent neu gestartet. Fortfahren?",
+  "couldNotLaunchDaw": "{daw} konnte nicht gestartet werden: {error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "Link konnte nicht geöffnet werden.",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "Mono",
   "monoToggleTooltip": "Mono-Wiedergabe umschalten",
   "monoRequiresWav": "Mono-Mischung erfordert eine WAV-Datei",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2610,6 +2610,33 @@
   "sortByPhase": "Phase",
   "sortByCreatedAt": "Date added",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "Newest first",
+  "sortOldestFirst": "Oldest first",
+  "sortTitleAZ": "Title A–Z",
+  "sortTitleZA": "Title Z–A",
+  "musicPlayerTab": "Music Player",
+  "previewAudioChangedRefreshing": "Preview audio changed on disk — refreshing waveform…",
+  "audioFileChangedRefreshing": "Audio file changed on disk — refreshing waveform…",
+  "autoFitAllColumns": "Auto fit all columns",
+  "uploadAutoDetectedPreviewSongs": "Upload auto-detected preview songs",
+  "uploadAutoDetectedPreviewSongsSubtitle": "Include songs found automatically by the scanner, not just ones you set manually.",
+  "monoGenerating": "Mono...",
+  "errorHandlingDroppedFiles": "Error handling dropped files: {error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "This will restart the setup wizard. Continue?",
+  "couldNotLaunchDaw": "Could not launch {daw}: {error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "Could not open link.",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "Mono",
   "monoToggleTooltip": "Toggle mono playback",
   "monoRequiresWav": "Mono mixing requires a WAV file",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1512,6 +1512,33 @@
   "sortByPhase": "Fase",
   "sortByCreatedAt": "Fecha de creación",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "Más recientes primero",
+  "sortOldestFirst": "Más antiguos primero",
+  "sortTitleAZ": "Título A–Z",
+  "sortTitleZA": "Título Z–A",
+  "musicPlayerTab": "Reproductor de música",
+  "previewAudioChangedRefreshing": "El audio de vista previa cambió en el disco — actualizando la forma de onda…",
+  "audioFileChangedRefreshing": "El archivo de audio cambió en el disco — actualizando la forma de onda…",
+  "autoFitAllColumns": "Ajustar automáticamente todas las columnas",
+  "uploadAutoDetectedPreviewSongs": "Subir canciones de vista previa detectadas automáticamente",
+  "uploadAutoDetectedPreviewSongsSubtitle": "Incluir canciones encontradas automáticamente por el escáner, no solo las que estableciste manualmente.",
+  "monoGenerating": "Mono…",
+  "errorHandlingDroppedFiles": "Error al procesar los archivos soltados: {error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "Esto reiniciará el asistente de configuración. ¿Continuar?",
+  "couldNotLaunchDaw": "No se pudo iniciar {daw}: {error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "No se pudo abrir el enlace.",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "Mono",
   "monoToggleTooltip": "Alternar reproducción mono",
   "monoRequiresWav": "La mezcla mono requiere un archivo WAV",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1512,6 +1512,33 @@
   "sortByPhase": "Phase",
   "sortByCreatedAt": "Date d'ajout",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "Plus récent d'abord",
+  "sortOldestFirst": "Plus ancien d'abord",
+  "sortTitleAZ": "Titre A–Z",
+  "sortTitleZA": "Titre Z–A",
+  "musicPlayerTab": "Lecteur de musique",
+  "previewAudioChangedRefreshing": "L'audio d'aperçu a changé sur le disque — actualisation de la forme d'onde…",
+  "audioFileChangedRefreshing": "Le fichier audio a changé sur le disque — actualisation de la forme d'onde…",
+  "autoFitAllColumns": "Ajuster automatiquement toutes les colonnes",
+  "uploadAutoDetectedPreviewSongs": "Envoyer les morceaux d'aperçu détectés automatiquement",
+  "uploadAutoDetectedPreviewSongsSubtitle": "Inclure les morceaux trouvés automatiquement par le scanner, pas seulement ceux définis manuellement.",
+  "monoGenerating": "Mono…",
+  "errorHandlingDroppedFiles": "Erreur lors du traitement des fichiers déposés : {error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "Cela relancera l'assistant de configuration. Continuer ?",
+  "couldNotLaunchDaw": "Impossible de lancer {daw} : {error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "Impossible d'ouvrir le lien.",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "Mono",
   "monoToggleTooltip": "Basculer en lecture mono",
   "monoRequiresWav": "Le mixage mono nécessite un fichier WAV",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1512,6 +1512,33 @@
   "sortByPhase": "Fase",
   "sortByCreatedAt": "Data aggiunta",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "Più recenti prima",
+  "sortOldestFirst": "Più vecchi prima",
+  "sortTitleAZ": "Titolo A–Z",
+  "sortTitleZA": "Titolo Z–A",
+  "musicPlayerTab": "Lettore musicale",
+  "previewAudioChangedRefreshing": "L'audio di anteprima è cambiato su disco — aggiornamento della forma d'onda…",
+  "audioFileChangedRefreshing": "Il file audio è cambiato su disco — aggiornamento della forma d'onda…",
+  "autoFitAllColumns": "Adatta automaticamente tutte le colonne",
+  "uploadAutoDetectedPreviewSongs": "Carica brani di anteprima rilevati automaticamente",
+  "uploadAutoDetectedPreviewSongsSubtitle": "Includi i brani trovati automaticamente dallo scanner, non solo quelli impostati manualmente.",
+  "monoGenerating": "Mono…",
+  "errorHandlingDroppedFiles": "Errore durante la gestione dei file trascinati: {error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "Questo riavvierà la procedura guidata di configurazione. Continuare?",
+  "couldNotLaunchDaw": "Impossibile avviare {daw}: {error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "Impossibile aprire il link.",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "Mono",
   "monoToggleTooltip": "Attiva/disattiva riproduzione mono",
   "monoRequiresWav": "Il mixaggio mono richiede un file WAV",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1512,6 +1512,33 @@
   "sortByPhase": "フェーズ",
   "sortByCreatedAt": "追加日",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "新しい順",
+  "sortOldestFirst": "古い順",
+  "sortTitleAZ": "タイトル A–Z",
+  "sortTitleZA": "タイトル Z–A",
+  "musicPlayerTab": "音楽プレーヤー",
+  "previewAudioChangedRefreshing": "プレビュー音声がディスク上で変更されました — 波形を更新中…",
+  "audioFileChangedRefreshing": "音声ファイルがディスク上で変更されました — 波形を更新中…",
+  "autoFitAllColumns": "すべての列を自動調整",
+  "uploadAutoDetectedPreviewSongs": "自動検出されたプレビュー曲をアップロード",
+  "uploadAutoDetectedPreviewSongsSubtitle": "手動で設定した曲だけでなく、スキャナーが自動的に見つけた曲も含めます。",
+  "monoGenerating": "モノラル…",
+  "errorHandlingDroppedFiles": "ドロップされたファイルの処理エラー: {error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "セットアップウィザードが再起動されます。続行しますか？",
+  "couldNotLaunchDaw": "{daw} を起動できませんでした: {error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "リンクを開けませんでした。",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "モノ",
   "monoToggleTooltip": "モノラル再生を切り替え",
   "monoRequiresWav": "モノラルミックスにはWAVファイルが必要です",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1536,6 +1536,33 @@
   "sortByPhase": "Fase",
   "sortByCreatedAt": "Data de criação",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "Mais recentes primeiro",
+  "sortOldestFirst": "Mais antigos primeiro",
+  "sortTitleAZ": "Título A–Z",
+  "sortTitleZA": "Título Z–A",
+  "musicPlayerTab": "Leitor de música",
+  "previewAudioChangedRefreshing": "O áudio de pré-visualização mudou no disco — atualizando a forma de onda…",
+  "audioFileChangedRefreshing": "O ficheiro de áudio mudou no disco — atualizando a forma de onda…",
+  "autoFitAllColumns": "Ajustar automaticamente todas as colunas",
+  "uploadAutoDetectedPreviewSongs": "Enviar músicas de pré-visualização detetadas automaticamente",
+  "uploadAutoDetectedPreviewSongsSubtitle": "Incluir músicas encontradas automaticamente pelo scanner, não apenas as definidas manualmente.",
+  "monoGenerating": "Mono…",
+  "errorHandlingDroppedFiles": "Erro ao processar os ficheiros largados: {error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "Isto irá reiniciar o assistente de configuração. Continuar?",
+  "couldNotLaunchDaw": "Não foi possível iniciar {daw}: {error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "Não foi possível abrir o link.",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "Mono",
   "monoToggleTooltip": "Alternar reprodução mono",
   "monoRequiresWav": "A mixagem mono requer um ficheiro WAV",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1512,6 +1512,33 @@
   "sortByPhase": "Фаза",
   "sortByCreatedAt": "Дата добавления",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "Сначала новые",
+  "sortOldestFirst": "Сначала старые",
+  "sortTitleAZ": "Название А–Я",
+  "sortTitleZA": "Название Я–А",
+  "musicPlayerTab": "Музыкальный плеер",
+  "previewAudioChangedRefreshing": "Аудио предпросмотра изменилось на диске — обновление формы волны…",
+  "audioFileChangedRefreshing": "Аудиофайл изменился на диске — обновление формы волны…",
+  "autoFitAllColumns": "Автоподбор ширины всех столбцов",
+  "uploadAutoDetectedPreviewSongs": "Загружать автоматически найденные превью-треки",
+  "uploadAutoDetectedPreviewSongsSubtitle": "Включать треки, автоматически найденные сканером, а не только заданные вручную.",
+  "monoGenerating": "Моно…",
+  "errorHandlingDroppedFiles": "Ошибка обработки перетащенных файлов: {error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "Это перезапустит мастер настройки. Продолжить?",
+  "couldNotLaunchDaw": "Не удалось запустить {daw}: {error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "Не удалось открыть ссылку.",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "Моно",
   "monoToggleTooltip": "Переключить моно воспроизведение",
   "monoRequiresWav": "Для монофонического микса требуется WAV-файл",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1512,6 +1512,33 @@
   "sortByPhase": "阶段",
   "sortByCreatedAt": "添加日期",
   "sortByBpm": "BPM",
+  "sortNewestFirst": "最新优先",
+  "sortOldestFirst": "最早优先",
+  "sortTitleAZ": "标题 A–Z",
+  "sortTitleZA": "标题 Z–A",
+  "musicPlayerTab": "音乐播放器",
+  "previewAudioChangedRefreshing": "预览音频在磁盘上已更改 — 正在刷新波形…",
+  "audioFileChangedRefreshing": "音频文件在磁盘上已更改 — 正在刷新波形…",
+  "autoFitAllColumns": "自动调整所有列",
+  "uploadAutoDetectedPreviewSongs": "上传自动检测到的预览歌曲",
+  "uploadAutoDetectedPreviewSongsSubtitle": "包括扫描器自动找到的歌曲，而不仅仅是手动设置的歌曲。",
+  "monoGenerating": "单声道…",
+  "errorHandlingDroppedFiles": "处理拖放文件时出错：{error}",
+  "@errorHandlingDroppedFiles": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "resetOnboardingConfirm": "这将重新启动设置向导。是否继续？",
+  "couldNotLaunchDaw": "无法启动 {daw}：{error}",
+  "@couldNotLaunchDaw": {
+    "placeholders": {
+      "daw": { "type": "String" },
+      "error": { "type": "String" }
+    }
+  },
+  "couldNotOpenLink": "无法打开链接。",
+  "githubButtonLabel": "GitHub",
   "monoLabel": "单声道",
   "monoToggleTooltip": "切换单声道播放",
   "monoRequiresWav": "单声道混音需要WAV文件",

--- a/lib/ui/dashboard_page.dart
+++ b/lib/ui/dashboard_page.dart
@@ -48,6 +48,7 @@ import 'widgets/language_switcher.dart';
 import 'widgets/theme_switcher.dart';
 import 'widgets/mobile_mini_player.dart';
 import '../generated/l10n/app_localizations.dart';
+import '../main.dart' show navigatorKey;
 import 'session_actions.dart';
 import 'dialogs/create_project_dialog.dart';
 import '../models/pending_folder.dart';
@@ -2124,7 +2125,7 @@ class _DashboardPageState extends ConsumerState<DashboardPage>
                             AppTab.playlists  => NavigationRailDestination(icon: const Icon(Icons.playlist_play), label: Text(AppLocalizations.of(context)!.playlists)),
                             AppTab.queue      => NavigationRailDestination(icon: const Icon(Icons.checklist), label: Text(AppLocalizations.of(context)!.queueTab)),
                             AppTab.statistics => NavigationRailDestination(icon: const Icon(Icons.bar_chart_rounded), label: Text(AppLocalizations.of(context)!.statisticsTab)),
-                            AppTab.player     => NavigationRailDestination(icon: const Icon(Icons.headphones), label: const Text('Music Player')),
+                            AppTab.player     => NavigationRailDestination(icon: const Icon(Icons.headphones), label: Text(AppLocalizations.of(context)!.musicPlayerTab)),
                           },
                       ],
                       trailing: Expanded(
@@ -5395,7 +5396,7 @@ class _PreviewSongDialogState extends ConsumerState<_PreviewSongDialog> {
   Future<void> _toggleMono() async {
     if (!_supportsMonoMix()) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Mono mixing is not supported for this format')),
+        SnackBar(content: Text(AppLocalizations.of(context)!.monoRequiresWav)),
       );
       return;
     }
@@ -5414,7 +5415,7 @@ class _PreviewSongDialogState extends ConsumerState<_PreviewSongDialog> {
         } else {
           setState(() => _isGeneratingMono = false);
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Could not create mono mix — unsupported format')),
+            SnackBar(content: Text(AppLocalizations.of(context)!.monoUnsupportedFormat)),
           );
           return;
         }
@@ -5447,7 +5448,7 @@ class _PreviewSongDialogState extends ConsumerState<_PreviewSongDialog> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Mono switch failed: $e')),
+          SnackBar(content: Text(AppLocalizations.of(context)!.monoSwitchFailed(e.toString()))),
         );
       }
     }
@@ -5700,7 +5701,7 @@ class _PreviewSongDialogState extends ConsumerState<_PreviewSongDialog> {
                   const SizedBox(width: 6),
                   GestureDetector(
                     onTap: _isGeneratingMono ? null : _toggleMono,
-                    child: Text('Mono', style: TextStyle(color: _isMono ? Colors.red : null)),
+                    child: Text(AppLocalizations.of(context)!.monoLabel, style: TextStyle(color: _isMono ? Colors.red : null)),
                   ),
                 ],
               ),
@@ -5840,7 +5841,7 @@ class _PreviewSongDialogState extends ConsumerState<_PreviewSongDialog> {
                   const SizedBox(width: 6),
                   GestureDetector(
                     onTap: _isGeneratingMono ? null : _toggleMono,
-                    child: Text('Mono', style: TextStyle(color: _isMono ? Colors.red : null)),
+                    child: Text(AppLocalizations.of(context)!.monoLabel, style: TextStyle(color: _isMono ? Colors.red : null)),
                   ),
                 ],
               ),
@@ -6349,9 +6350,9 @@ class _DesktopPlayerBarState extends ConsumerState<_DesktopPlayerBar> {
       onStale: () {
         if (!mounted) return;
         setState(() => _peaks = null);
-        ScaffoldMessenger.maybeOf(context)?.showSnackBar(const SnackBar(
-          content: Text('Preview audio changed on disk — refreshing waveform…'),
-          duration: Duration(seconds: 3),
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(SnackBar(
+          content: Text(AppLocalizations.of(context)!.previewAudioChangedRefreshing),
+          duration: const Duration(seconds: 3),
         ));
       },
     ).then((peaks) {
@@ -6664,7 +6665,7 @@ class _DesktopPlayerBarState extends ConsumerState<_DesktopPlayerBar> {
                           const SizedBox(width: 6),
                           GestureDetector(
                             onTap: _isGeneratingMono ? null : _toggleMono,
-                            child: Text('Mono', style: TextStyle(fontSize: 11, color: _isMono ? Colors.red : null)),
+                            child: Text(AppLocalizations.of(context)!.monoLabel, style: TextStyle(fontSize: 11, color: _isMono ? Colors.red : null)),
                           ),
                         ],
                       ),
@@ -7520,16 +7521,18 @@ class _FitAllColumnsMenuDelegate
       stateManager: stateManager,
       column: column,
     );
+    final context = navigatorKey.currentContext;
+    final label = context != null ? AppLocalizations.of(context)!.autoFitAllColumns : 'Auto fit all columns';
     return [
       ...defaults,
       const PopupMenuDivider(),
-      const PopupMenuItem<String>(
+      PopupMenuItem<String>(
         value: _menuFitAll,
         child: Row(
           children: [
-            Icon(Icons.fit_screen, size: 16),
-            SizedBox(width: 8),
-            Text('Auto fit all columns'),
+            const Icon(Icons.fit_screen, size: 16),
+            const SizedBox(width: 8),
+            Text(label),
           ],
         ),
       ),

--- a/lib/ui/dialogs/create_project_dialog.dart
+++ b/lib/ui/dialogs/create_project_dialog.dart
@@ -217,7 +217,7 @@ class _CreateProjectDialogState extends ConsumerState<CreateProjectDialog> {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text('Could not launch ${_selectedDaw!.name}: $e'),
+              content: Text(AppLocalizations.of(context)!.couldNotLaunchDaw(_selectedDaw!.name, e.toString())),
               duration: const Duration(seconds: 6),
             ),
           );

--- a/lib/ui/google_drive_sync_page.dart
+++ b/lib/ui/google_drive_sync_page.dart
@@ -1181,11 +1181,10 @@ class _GoogleDriveSyncPageState extends ConsumerState<GoogleDriveSyncPage> {
                     const Divider(height: 24),
                     SwitchListTile(
                       contentPadding: EdgeInsets.zero,
-                      title: const Text('Upload auto-detected preview songs',
-                          style: TextStyle(fontSize: 14)),
+                      title: Text(AppLocalizations.of(context)!.uploadAutoDetectedPreviewSongs,
+                          style: const TextStyle(fontSize: 14)),
                       subtitle: Text(
-                        'Include songs found automatically by the scanner, '
-                        'not just ones you set manually.',
+                        AppLocalizations.of(context)!.uploadAutoDetectedPreviewSongsSubtitle,
                         style: TextStyle(fontSize: 12, color: Colors.grey[600]),
                       ),
                       value: ref.watch(uploadAutoPreviewSongsProvider),

--- a/lib/ui/mobile_player_page.dart
+++ b/lib/ui/mobile_player_page.dart
@@ -414,7 +414,7 @@ class _MobilePlayerPageState extends ConsumerState<MobilePlayerPage> {
                                           child: CircularProgressIndicator(strokeWidth: 2),
                                         ),
                                         const SizedBox(width: 6),
-                                        Text('Mono...', style: theme.textTheme.bodySmall),
+                                        Text(AppLocalizations.of(context)!.monoGenerating, style: theme.textTheme.bodySmall),
                                       ],
                                     )
                                   : GestureDetector(

--- a/lib/ui/onboarding_wizard_page.dart
+++ b/lib/ui/onboarding_wizard_page.dart
@@ -638,6 +638,7 @@ class _ThemePreviewMockup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     const textColor = Colors.white;
     const dimText = Color(0xFFAAAAAA);
 
@@ -677,9 +678,9 @@ class _ThemePreviewMockup extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 2),
             child: Row(
               children: [
-                _previewText('Name', dimText, flex: 3),
-                _previewText('Status', dimText, flex: 2),
-                _previewText('BPM', dimText, flex: 1),
+                _previewText(l10n.name, dimText, flex: 3),
+                _previewText(l10n.status, dimText, flex: 2),
+                _previewText(l10n.bpm, dimText, flex: 1),
               ],
             ),
           ),

--- a/lib/ui/project_detail_page.dart
+++ b/lib/ui/project_detail_page.dart
@@ -1356,9 +1356,9 @@ class _PreviewSongPlayerState extends ConsumerState<_PreviewSongPlayer> {
       onStale: () {
         if (!mounted) return;
         setState(() => _peaks = null);
-        ScaffoldMessenger.maybeOf(context)?.showSnackBar(const SnackBar(
-          content: Text('Preview audio changed on disk — refreshing waveform…'),
-          duration: Duration(seconds: 3),
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(SnackBar(
+          content: Text(AppLocalizations.of(context)!.previewAudioChangedRefreshing),
+          duration: const Duration(seconds: 3),
         ));
       },
     ).then((peaks) {
@@ -2199,7 +2199,7 @@ class _PreviewSongPlayerState extends ConsumerState<_PreviewSongPlayer> {
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: Text('Error handling dropped files: ${e.toString()}'),
+                content: Text(AppLocalizations.of(context)!.errorHandlingDroppedFiles(e.toString())),
               ),
             );
           }

--- a/lib/ui/project_folders_settings_page.dart
+++ b/lib/ui/project_folders_settings_page.dart
@@ -517,7 +517,7 @@ class _ProjectFoldersSettingsPageState extends ConsumerState<ProjectFoldersSetti
                       context: context,
                       builder: (ctx) => AlertDialog(
                         title: Text(l10n.resetOnboarding),
-                        content: const Text('This will restart the setup wizard. Continue?'),
+                        content: Text(l10n.resetOnboardingConfirm),
                         actions: [
                           TextButton(
                             onPressed: () => Navigator.of(ctx).pop(false),

--- a/lib/ui/release_detail_page.dart
+++ b/lib/ui/release_detail_page.dart
@@ -2283,9 +2283,9 @@ class _AudioFileItemState extends ConsumerState<_AudioFileItem> {
       onStale: () {
         if (!mounted) return;
         setState(() => _peaks = null);
-        ScaffoldMessenger.maybeOf(context)?.showSnackBar(const SnackBar(
-          content: Text('Audio file changed on disk — refreshing waveform…'),
-          duration: Duration(seconds: 3),
+        ScaffoldMessenger.maybeOf(context)?.showSnackBar(SnackBar(
+          content: Text(AppLocalizations.of(context)!.audioFileChangedRefreshing),
+          duration: const Duration(seconds: 3),
         ));
       },
     ).then((peaks) {

--- a/lib/ui/releases_tab_page.dart
+++ b/lib/ui/releases_tab_page.dart
@@ -242,11 +242,11 @@ class _ReleasesTabPageState extends ConsumerState<ReleasesTabPage> {
                       underline: const SizedBox.shrink(),
                       style: TextStyle(fontSize: 12, color: Theme.of(context).textTheme.bodyMedium?.color),
                       icon: Icon(Icons.sort, size: 16, color: Theme.of(context).textTheme.bodyMedium?.color),
-                      items: const [
-                        DropdownMenuItem(value: ReleasesSort.dateDesc, child: Text('Newest first')),
-                        DropdownMenuItem(value: ReleasesSort.dateAsc, child: Text('Oldest first')),
-                        DropdownMenuItem(value: ReleasesSort.titleAsc, child: Text('Title A–Z')),
-                        DropdownMenuItem(value: ReleasesSort.titleDesc, child: Text('Title Z–A')),
+                      items: [
+                        DropdownMenuItem(value: ReleasesSort.dateDesc, child: Text(l10n.sortNewestFirst)),
+                        DropdownMenuItem(value: ReleasesSort.dateAsc, child: Text(l10n.sortOldestFirst)),
+                        DropdownMenuItem(value: ReleasesSort.titleAsc, child: Text(l10n.sortTitleAZ)),
+                        DropdownMenuItem(value: ReleasesSort.titleDesc, child: Text(l10n.sortTitleZA)),
                       ],
                       onChanged: (v) {
                         if (v != null) ref.read(releasesSortProvider.notifier).setSort(v);

--- a/lib/ui/widgets/update_available_dialog.dart
+++ b/lib/ui/widgets/update_available_dialog.dart
@@ -27,16 +27,17 @@ class UpdateAvailableDialog extends StatelessWidget {
     );
   }
 
-  Future<void> _launch(Uri uri, ScaffoldMessengerState messenger) async {
+  Future<void> _launch(Uri uri, ScaffoldMessengerState messenger, String couldNotOpenLinkMessage) async {
     if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
       messenger.showSnackBar(
-        const SnackBar(content: Text('Could not open link.')),
+        SnackBar(content: Text(couldNotOpenLinkMessage)),
       );
     }
   }
 
   Future<void> _openStoreLink(BuildContext context) async {
     final messenger = ScaffoldMessenger.of(context);
+    final couldNotOpenLinkMessage = AppLocalizations.of(context)!.couldNotOpenLink;
     Uri uri;
     if (Platform.isWindows && _kWindowsStoreId.isNotEmpty) {
       uri = Uri.parse('https://www.microsoft.com/store/apps/$_kWindowsStoreId');
@@ -46,27 +47,29 @@ class UpdateAvailableDialog extends StatelessWidget {
     } else {
       return;
     }
-    await _launch(uri, messenger);
+    await _launch(uri, messenger, couldNotOpenLinkMessage);
   }
 
   Future<void> _openGitHubRelease(BuildContext context) async {
     if (_kGithubOwner.isEmpty || _kGithubRepo.isEmpty) return;
     final messenger = ScaffoldMessenger.of(context);
+    final couldNotOpenLinkMessage = AppLocalizations.of(context)!.couldNotOpenLink;
     final uri = Uri.parse(
         'https://github.com/$_kGithubOwner/$_kGithubRepo/releases/tag/v$version');
-    await _launch(uri, messenger);
+    await _launch(uri, messenger, couldNotOpenLinkMessage);
   }
 
   Future<void> _openMsStoreApp(BuildContext context) async {
     if (_kWindowsStoreId.isEmpty) return;
     final messenger = ScaffoldMessenger.of(context);
+    final couldNotOpenLinkMessage = AppLocalizations.of(context)!.couldNotOpenLink;
     final storeUri =
         Uri.parse('ms-windows-store://pdp/?productid=$_kWindowsStoreId');
     final webUri = Uri.parse(
         'https://www.microsoft.com/store/apps/$_kWindowsStoreId');
     // Try the ms-windows-store:// protocol first; fall back to web URL.
     if (!await launchUrl(storeUri)) {
-      await _launch(webUri, messenger);
+      await _launch(webUri, messenger, couldNotOpenLinkMessage);
     }
   }
 
@@ -203,7 +206,7 @@ class UpdateAvailableDialog extends StatelessWidget {
         if (_kGithubOwner.isNotEmpty && _kGithubRepo.isNotEmpty)
           TextButton.icon(
             icon: const Icon(Icons.open_in_new, size: 14),
-            label: const Text('GitHub'),
+            label: Text(AppLocalizations.of(context)!.githubButtonLabel),
             onPressed: () => _openGitHubRelease(context),
           ),
         TextButton(


### PR DESCRIPTION
Replace hardcoded English text in the releases sort dropdown, mono playback controls, waveform-stale snackbars, onboarding preview column headers, and several dialog/snackbar messages with AppLocalizations lookups, adding the corresponding keys to all 9 locale ARB files.