### PR TITLE
Fix macOS build failure from removed NSApplication.activate(options:)…

### DIFF
--- a/lib/services/google_drive_sync_service.dart
+++ b/lib/services/google_drive_sync_service.dart
@@ -2083,6 +2083,18 @@ class GoogleDriveSyncService {
     return _mergeHashCache[filePath] ??= await _calculateFileHash(filePath);
   }
 
+  /// Returns the basename of [filePath] to use as a preview song's display name,
+  /// unless it looks like one of our own Drive-download filenames
+  /// (`<uuid>_preview.<ext>`) — in which case there is no real original name to
+  /// recover from it and null is returned instead. Used as the fallback when
+  /// restoring a backup that predates the `previewSongFileNames` manifest map,
+  /// so a UUID never gets stored as a project's "original" preview filename.
+  String? _realPreviewFileNameOrNull(String? filePath) {
+    if (filePath == null) return null;
+    final basename = path.basename(filePath);
+    return _uuidPreviewRe.hasMatch(basename) ? null : basename;
+  }
+
   /// Returns true if [localProject.previewSongAutoPath] already points at a file on
   /// disk whose hash matches [expectedHash] (falling back to the project's last
   /// recorded [MusicProject.uploadedPreviewSongHash] when [expectedHash] is
@@ -3632,10 +3644,11 @@ class GoogleDriveSyncService {
                     // Fallback for old backups that predate the previewSongFileNames map:
                     // use the basename of the remote project's path (the real filename on
                     // the uploading machine) rather than showing a UUID filename.
-                    originalFileName ??= (remoteProject.previewSongPath != null &&
-                            !_isDriveFileReference(remoteProject.previewSongPath!))
-                        ? path.basename(remoteProject.previewSongPath!)
-                        : null;
+                    if (originalFileName == null &&
+                        remoteProject.previewSongPath != null &&
+                        !_isDriveFileReference(remoteProject.previewSongPath!)) {
+                      originalFileName = _realPreviewFileNameOrNull(remoteProject.previewSongPath);
+                    }
                     if (previewSongHashes != null && previewSongHashes.containsKey(remoteProject.id)) {
                       expectedHash = previewSongHashes[remoteProject.id] as String;
                     }
@@ -3733,7 +3746,7 @@ class GoogleDriveSyncService {
                       if (previewSongFileName == null &&
                           remoteProject.previewSongPath != null &&
                           !_isDriveFileReference(remoteProject.previewSongPath!)) {
-                        previewSongFileName = path.basename(remoteProject.previewSongPath!);
+                        previewSongFileName = _realPreviewFileNameOrNull(remoteProject.previewSongPath);
                       }
                       if (previewSongHashes != null && previewSongHashes.containsKey(remoteProject.id)) {
                         uploadedPreviewSongHash = previewSongHashes[remoteProject.id] as String;
@@ -3982,7 +3995,7 @@ class GoogleDriveSyncService {
                       if (originalFileName == null &&
                           remoteProject.previewSongPath != null &&
                           !_isDriveFileReference(remoteProject.previewSongPath!)) {
-                        originalFileName = path.basename(remoteProject.previewSongPath!);
+                        originalFileName = _realPreviewFileNameOrNull(remoteProject.previewSongPath);
                       }
                       if (previewSongHashes != null && previewSongHashes.containsKey(remoteProject.id)) {
                         expectedHash = previewSongHashes[remoteProject.id] as String;
@@ -4708,6 +4721,11 @@ class GoogleDriveSyncService {
   Future<bool> autoPreviewAlreadyMatchesForTest(MusicProject localProject, String? expectedHash) =>
       _autoPreviewAlreadyMatches(localProject, expectedHash);
 
+  /// Test-only accessor for [_realPreviewFileNameOrNull].
+  @visibleForTesting
+  String? realPreviewFileNameOrNullForTest(String? filePath) =>
+      _realPreviewFileNameOrNull(filePath);
+
   Map<String, dynamic> _serializeRelease(Release release) {
     return {
       'id': release.id,
@@ -4872,10 +4890,11 @@ class GoogleDriveSyncService {
     if (previewSongFiles != null && previewSongFiles.containsKey(projectId)) {
       final driveFileId = previewSongFiles[projectId] as String;
       String? originalFileName = previewSongFileNames?[projectId] as String?;
-      originalFileName ??= (remoteProject.previewSongPath != null &&
-              !_isDriveFileReference(remoteProject.previewSongPath!))
-          ? path.basename(remoteProject.previewSongPath!)
-          : null;
+      if (originalFileName == null &&
+          remoteProject.previewSongPath != null &&
+          !_isDriveFileReference(remoteProject.previewSongPath!)) {
+        originalFileName = _realPreviewFileNameOrNull(remoteProject.previewSongPath);
+      }
       final expectedHash = previewSongHashes?[projectId] as String?;
       final fileExtension =
           originalFileName != null ? path.extension(originalFileName) : null;

--- a/lib/services/google_drive_sync_service.dart
+++ b/lib/services/google_drive_sync_service.dart
@@ -2083,6 +2083,29 @@ class GoogleDriveSyncService {
     return _mergeHashCache[filePath] ??= await _calculateFileHash(filePath);
   }
 
+  /// Returns true if [localProject.previewSongAutoPath] already points at a file on
+  /// disk whose hash matches [expectedHash] (falling back to the project's last
+  /// recorded [MusicProject.uploadedPreviewSongHash] when [expectedHash] is
+  /// unavailable). Used during merge to avoid re-downloading a preview from Drive
+  /// into `previewSongPath` when the auto-detected file already on this device is
+  /// the same one that's already backed up — downloading it anyway would duplicate
+  /// the file under a UUID-named copy and silently promote an auto-detected preview
+  /// into a manually-pinned one, overriding the "auto-detected" status in the UI.
+  Future<bool> _autoPreviewAlreadyMatches(MusicProject localProject, String? expectedHash) async {
+    final autoPath = localProject.previewSongAutoPath;
+    if (autoPath == null || autoPath.isEmpty) return false;
+    final hashToMatch = expectedHash ?? localProject.uploadedPreviewSongHash;
+    if (hashToMatch == null) return false;
+    try {
+      final autoFile = File(autoPath);
+      if (!await autoFile.exists()) return false;
+      final autoHash = await _cachedFileHash(autoPath);
+      return autoHash == hashToMatch;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// Retry [fn] up to [maxAttempts] times on transient Drive/network errors using
   /// exponential backoff (2 s, 4 s, 8 s …) with ±25 % jitter.
   /// Throws immediately on cancellation or non-retryable errors.
@@ -3787,8 +3810,16 @@ class GoogleDriveSyncService {
                             // Path exists but file doesn't - need to download
                             needsDownload = true;
                           }
-                        } else if (previewSongPath == null || _isDriveFileReference(previewSongPath)) {
-                          // No local path or Drive reference - need to download
+                        } else if (previewSongPath == null) {
+                          // No manually-set local path. Before downloading, check whether
+                          // the auto-detected preview already on this device is the exact
+                          // file that's on Drive (e.g. this device is the one that uploaded
+                          // it) - if so, skip the download so we don't duplicate it under a
+                          // UUID filename and silently promote previewSongAutoPath into
+                          // previewSongPath.
+                          needsDownload = !await _autoPreviewAlreadyMatches(localProject, uploadedPreviewSongHash);
+                        } else if (_isDriveFileReference(previewSongPath)) {
+                          // Drive reference - need to download
                           needsDownload = true;
                         } else if (uploadedPreviewSongHash != null && localProject.uploadedPreviewSongHash != uploadedPreviewSongHash) {
                           // Hash changed - need to download
@@ -4026,8 +4057,16 @@ class GoogleDriveSyncService {
                             // Path exists but file doesn't - need to download
                             needsDownload = true;
                           }
-                        } else if (previewSongPath == null || _isDriveFileReference(previewSongPath)) {
-                          // No local path or Drive reference - need to download
+                        } else if (previewSongPath == null) {
+                          // No manually-set local path. Before downloading, check whether
+                          // the auto-detected preview already on this device is the exact
+                          // file that's on Drive (e.g. this device is the one that uploaded
+                          // it) - if so, skip the download so we don't duplicate it under a
+                          // UUID filename and silently promote previewSongAutoPath into
+                          // previewSongPath.
+                          needsDownload = !await _autoPreviewAlreadyMatches(localProject, expectedHash);
+                        } else if (_isDriveFileReference(previewSongPath)) {
+                          // Drive reference - need to download
                           needsDownload = true;
                         } else if (expectedHash != null && uploadedPreviewSongHash != expectedHash) {
                           // Hash changed - need to download
@@ -4660,6 +4699,14 @@ class GoogleDriveSyncService {
   @visibleForTesting
   MusicProject deserializeProjectForTest(Map<String, dynamic> data) =>
       _deserializeProject(data);
+
+  /// Test-only accessor for [_autoPreviewAlreadyMatches] — the merge-time check
+  /// that stops a locally auto-detected preview from being re-downloaded (and
+  /// promoted into [MusicProject.previewSongPath]) when it's already the same
+  /// file that's on Drive.
+  @visibleForTesting
+  Future<bool> autoPreviewAlreadyMatchesForTest(MusicProject localProject, String? expectedHash) =>
+      _autoPreviewAlreadyMatches(localProject, expectedHash);
 
   Map<String, dynamic> _serializeRelease(Release release) {
     return {

--- a/lib/services/mixdown_detector_service.dart
+++ b/lib/services/mixdown_detector_service.dart
@@ -14,6 +14,17 @@ class MixdownDetectorService {
     '.wav', '.mp3', '.flac', '.aif', '.aiff', '.aac', '.m4a', '.ogg',
   };
 
+  // Matches this app's own Drive-download filenames — "<uuid>_preview.<ext>" —
+  // written by GoogleDriveSyncService.downloadPreviewSongFile into a single
+  // "preview_songs" cache directory shared by every project. That directory is
+  // not a per-project export folder, so a "same folder" scan must never run
+  // against it: it would surface other projects' downloaded previews as false
+  // "newer export found" hits.
+  static final RegExp _driveDownloadFileRe = RegExp(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_preview\.',
+    caseSensitive: false,
+  );
+
   /// Per-DAW folder names to check, in priority order.
   /// Values match the `dawType` strings produced by metadata_extractor.dart.
   /// Exposed publicly so settings UI can explain the defaults to the user.
@@ -72,13 +83,16 @@ class MixdownDetectorService {
 
   /// Returns the newest audio file in the same directory as [currentPath] if it
   /// is strictly newer than [currentPath] itself and is a different file.
-  /// Returns null if [currentPath] is already the newest, doesn't exist, or on mobile.
+  /// Returns null if [currentPath] is already the newest, doesn't exist, is on
+  /// mobile, or lives in the shared Drive-download preview cache (that folder
+  /// holds every project's downloaded preview, not just this project's exports).
   ///
   /// [ignoredPath] is a path the user has previously rejected ("Keep Current").
   /// If the newest file matches it, the prompt is suppressed until a genuinely
   /// different (even newer) file appears.
   static File? findNewerFileInSameFolder(String currentPath, {String? ignoredPath}) {
     if (MobileUtils.isMobile()) return null;
+    if (_driveDownloadFileRe.hasMatch(p.basename(currentPath))) return null;
     final current = File(currentPath);
     if (!current.existsSync()) return null;
     final currentModified = current.lastModifiedSync();

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -36,7 +36,7 @@ class AppDelegate: FlutterAppDelegate {
 
   @objc private func handleShowWindowRequest() {
     DispatchQueue.main.async {
-      NSApp.activate(options: .activateIgnoringOtherApps)
+      NSApp.activate()
       NSApplication.shared.windows.first?.makeKeyAndOrderFront(nil)
     }
   }

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -36,7 +36,11 @@ class AppDelegate: FlutterAppDelegate {
 
   @objc private func handleShowWindowRequest() {
     DispatchQueue.main.async {
-      NSApp.activate()
+      if #available(macOS 14.0, *) {
+        NSApp.activate()
+      } else {
+        NSApp.activate(ignoringOtherApps: true)
+      }
       NSApplication.shared.windows.first?.makeKeyAndOrderFront(nil)
     }
   }

--- a/test/services/google_drive_sync_service_test.dart
+++ b/test/services/google_drive_sync_service_test.dart
@@ -461,4 +461,53 @@ void main() {
       );
     });
   });
+
+  group('GoogleDriveSyncService._realPreviewFileNameOrNull', () {
+    // Regression: when restoring a backup that predates the previewSongFileNames
+    // manifest map, mergeData() fell back to path.basename(remoteProject.previewSongPath)
+    // for the display name with no check on what that basename actually was. If the
+    // remote project's own previewSongPath was itself a previously-downloaded Drive
+    // copy (named "<uuid>_preview.<ext>" by downloadPreviewSongFile), that UUID name
+    // would be written into previewSongFileName and propagate through the whole sync
+    // mesh on every future re-upload (uploadDatabase prefers project.previewSongFileName
+    // over recomputing it). The dashboard's _displayFileName() already refuses to
+    // *show* a UUID name, but that only masked the bad data rather than preventing it
+    // from being stored. _realPreviewFileNameOrNull() closes the gap at the source, so
+    // all four merge/restore call sites that derive a name from a remote path can never
+    // write a UUID-shaped name into previewSongFileName in the first place.
+    late GoogleDriveSyncService service;
+
+    setUp(() {
+      service = GoogleDriveSyncService();
+    });
+
+    test('returns the basename for a real, non-UUID filename', () {
+      expect(
+        service.realPreviewFileNameOrNullForTest('/Users/artist/Live Sets/Bounces/mixdown_final.wav'),
+        'mixdown_final.wav',
+      );
+    });
+
+    test('returns null for a Drive-download-shaped UUID filename', () {
+      expect(
+        service.realPreviewFileNameOrNullForTest(
+          '/Users/artist/AppSupport/preview_songs/3fa85f64-5717-4562-b3fc-2c963f66afa6_preview.mp3',
+        ),
+        isNull,
+      );
+    });
+
+    test('is case-insensitive when matching the UUID pattern', () {
+      expect(
+        service.realPreviewFileNameOrNullForTest(
+          '/tmp/3FA85F64-5717-4562-B3FC-2C963F66AFA6_preview.wav',
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null when the path itself is null', () {
+      expect(service.realPreviewFileNameOrNullForTest(null), isNull);
+    });
+  });
 }

--- a/test/services/google_drive_sync_service_test.dart
+++ b/test/services/google_drive_sync_service_test.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:googleapis/drive/v3.dart' as drive;
 import 'package:googleapis_auth/auth_io.dart' as auth_io;
 import 'package:hive_ce/hive.dart';
 import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as path;
 import 'package:daw_project_manager/models/profile.dart';
 import 'package:daw_project_manager/repository/profile_repository.dart';
 import 'package:daw_project_manager/repository/project_repository.dart';
@@ -363,5 +365,100 @@ void main() {
         expect(merged.lastModifiedAt, localLastModifiedAt);
       },
     );
+  });
+
+  group('GoogleDriveSyncService._autoPreviewAlreadyMatches', () {
+    // Regression: the auto-backup timer switched from uploadDatabase() to
+    // syncDatabase() (which downloads+merges before re-uploading) so a newer
+    // Drive backup from another device wouldn't be silently clobbered. That
+    // meant every routine desktop auto-backup now runs mergeData()'s preview
+    // song reconciliation too. For a project whose preview was only ever
+    // auto-detected (previewSongAutoPath set, previewSongPath null) and had
+    // been auto-uploaded to Drive, mergeData saw previewSongPath == null and
+    // concluded "we don't have this file yet", re-downloading a byte-identical
+    // copy under a UUID-based filename and writing it into previewSongPath —
+    // which outranks previewSongAutoPath everywhere in the UI, so the desktop
+    // preview silently switched to the new UUID-named duplicate and the
+    // "auto-detected" badge disappeared. _autoPreviewAlreadyMatches() is the
+    // guard added to catch this: mergeData now consults it before deciding a
+    // preview needs to be (re)downloaded.
+    //
+    // Exercising this from mergeData() end-to-end would require a real
+    // driveApi/credentials round trip (downloadPreviewSongFile talks to
+    // Drive), so the closest automatable test is the helper itself, which
+    // contains the actual decision logic that was missing before the fix.
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('auto_preview_test');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) await tempDir.delete(recursive: true);
+    });
+
+    test('returns true when the auto-detected file on disk matches the expected hash', () async {
+      final autoPath = path.join(tempDir.path, 'mixdown.wav');
+      await File(autoPath).writeAsBytes([1, 2, 3, 4]);
+      final expectedHash = md5.convert([1, 2, 3, 4]).toString();
+
+      final project = TestFactories.makeProject(previewSongAutoPath: autoPath);
+
+      final service = GoogleDriveSyncService();
+      expect(
+        await service.autoPreviewAlreadyMatchesForTest(project, expectedHash),
+        isTrue,
+      );
+    });
+
+    test('falls back to the project\'s stored uploadedPreviewSongHash when expectedHash is null', () async {
+      final autoPath = path.join(tempDir.path, 'mixdown.wav');
+      await File(autoPath).writeAsBytes([5, 6, 7, 8]);
+      final storedHash = md5.convert([5, 6, 7, 8]).toString();
+
+      final project = TestFactories.makeProject(previewSongAutoPath: autoPath)
+          .copyWith(uploadedPreviewSongHash: storedHash);
+
+      final service = GoogleDriveSyncService();
+      expect(
+        await service.autoPreviewAlreadyMatchesForTest(project, null),
+        isTrue,
+      );
+    });
+
+    test('returns false when the auto-detected file\'s hash differs from Drive\'s', () async {
+      final autoPath = path.join(tempDir.path, 'mixdown.wav');
+      await File(autoPath).writeAsBytes([1, 2, 3, 4]);
+      final differentHash = md5.convert([9, 9, 9, 9]).toString();
+
+      final project = TestFactories.makeProject(previewSongAutoPath: autoPath);
+
+      final service = GoogleDriveSyncService();
+      expect(
+        await service.autoPreviewAlreadyMatchesForTest(project, differentHash),
+        isFalse,
+      );
+    });
+
+    test('returns false when previewSongAutoPath is not set', () async {
+      final project = TestFactories.makeProject();
+
+      final service = GoogleDriveSyncService();
+      expect(
+        await service.autoPreviewAlreadyMatchesForTest(project, 'anyhash'),
+        isFalse,
+      );
+    });
+
+    test('returns false when the auto-detected file no longer exists on disk', () async {
+      final missingPath = path.join(tempDir.path, 'does-not-exist.wav');
+      final project = TestFactories.makeProject(previewSongAutoPath: missingPath);
+
+      final service = GoogleDriveSyncService();
+      expect(
+        await service.autoPreviewAlreadyMatchesForTest(project, 'anyhash'),
+        isFalse,
+      );
+    });
   });
 }

--- a/test/services/mixdown_detector_service_test.dart
+++ b/test/services/mixdown_detector_service_test.dart
@@ -65,6 +65,53 @@ void main() {
       }
     });
 
+    test(
+      'returns null when currentPath is a Drive-download cache file, even if a '
+      'newer file sits next to it (belonging to a different project)',
+      () async {
+        // Regression: GoogleDriveSyncService.downloadPreviewSongFile writes every
+        // project's downloaded preview into one shared "preview_songs" directory,
+        // named "<projectId>_preview.<ext>". Before this guard, playing project A
+        // right after project B's preview was (re)downloaded in the same sync pass
+        // would scan that shared folder, see project B's fresher file, and offer to
+        // replace project A's preview with it — a completely unrelated project's file.
+        final dir = await Directory.systemTemp.createTemp('mixdown_drive_cache_');
+        try {
+          final projectA = File(
+            '${dir.path}/3fa85f64-5717-4562-b3fc-2c963f66afa6_preview.mp3',
+          );
+          final projectB = File(
+            '${dir.path}/7c9e6679-7425-40de-944b-e07fc1f90ae7_preview.mp3',
+          );
+          await projectA.create();
+          await projectB.create();
+          projectA.setLastModifiedSync(DateTime(2024, 1, 1));
+          projectB.setLastModifiedSync(DateTime(2025, 1, 1)); // freshly re-downloaded
+
+          final result = MixdownDetectorService.findNewerFileInSameFolder(projectA.path);
+          expect(result, isNull);
+        } finally {
+          await dir.delete(recursive: true);
+        }
+      },
+    );
+
+    test('is case-insensitive when recognizing a Drive-download cache filename', () async {
+      final dir = await Directory.systemTemp.createTemp('mixdown_drive_cache_ci_');
+      try {
+        final current = File('${dir.path}/3FA85F64-5717-4562-B3FC-2C963F66AFA6_preview.wav');
+        final other = File('${dir.path}/other.wav');
+        await current.create();
+        await other.create();
+        current.setLastModifiedSync(DateTime(2024, 1, 1));
+        other.setLastModifiedSync(DateTime(2025, 1, 1));
+
+        expect(MixdownDetectorService.findNewerFileInSameFolder(current.path), isNull);
+      } finally {
+        await dir.delete(recursive: true);
+      }
+    });
+
     test('returns null when the newest file matches ignoredPath', () async {
       final dir = await Directory.systemTemp.createTemp('mixdown_ignored_');
       try {


### PR DESCRIPTION
… overload

Newer macOS SDKs (Xcode 26.5) dropped the options-based activate overload in favor of a parameterless activate(), which already ignores other apps by default.