### PR TITLE
Fix Windows project launch failure for paths containing '#' (#62)

### DIFF
--- a/lib/utils/file_launcher_platform_macos.dart
+++ b/lib/utils/file_launcher_platform_macos.dart
@@ -3,11 +3,14 @@
 // so Windows/Linux builds may still compile this file; the plugin often
 // compiles on all platforms with no-op native code on non-macOS.
 
+import 'dart:ffi';
 import 'dart:io';
 
+import 'package:ffi/ffi.dart';
 import 'package:flutter/foundation.dart';
 import 'package:macos_secure_bookmarks/macos_secure_bookmarks.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:win32/win32.dart' as win32;
 
 final SecureBookmarks _secureBookmarks = SecureBookmarks();
 
@@ -49,13 +52,58 @@ Future<String> createBookmarkForPath(String path) async {
   return _secureBookmarks.bookmark(file);
 }
 
-/// Checks existence and launches the path with url_launcher.
+/// Whether [path] needs the direct-ShellExecuteW workaround below instead of
+/// going through url_launcher, on Windows.
+///
+/// url_launcher_windows unescapes %-encoded file:// URLs before calling
+/// ShellExecuteW (to support UTF-8 paths). That reintroduces literal '#'
+/// characters into the still-"file://"-prefixed string, which ShellExecuteW
+/// then reparses as a URL, treating '#' as a fragment delimiter and silently
+/// truncating the path there. Only paths containing '#' hit this, so
+/// everything else keeps going through url_launcher unchanged.
+@visibleForTesting
+bool windowsNeedsDirectShellExecute(String path) =>
+    Platform.isWindows && path.contains('#');
+
+/// Calls ShellExecuteW directly with the raw filesystem path — never a
+/// `file://` URI — so there is no percent-encode/unescape round-trip for
+/// ShellExecuteW to misinterpret. Per the Win32 docs, a return value greater
+/// than 32 indicates success.
+bool _shellExecuteOpen(String path) {
+  final operation = 'open'.toNativeUtf16();
+  final file = path.toNativeUtf16();
+  try {
+    final result = win32.ShellExecute(
+      0,
+      operation,
+      file,
+      nullptr,
+      nullptr,
+      win32.SW_SHOWNORMAL,
+    );
+    return result > 32;
+  } finally {
+    calloc.free(operation);
+    calloc.free(file);
+  }
+}
+
+/// Checks existence and launches the path with url_launcher, except for
+/// Windows paths containing '#' which go through [_shellExecuteOpen] instead
+/// — see [windowsNeedsDirectShellExecute] for why.
 Future<bool> launchResolvedPath(String path, bool isFolder) async {
   final entity = isFolder ? Directory(path) : File(path);
   if (!await entity.exists()) {
     if (kDebugMode) print('[FileLauncher] ERROR: Path does not exist: $path');
     return false;
   }
+
+  if (windowsNeedsDirectShellExecute(path)) {
+    final launched = _shellExecuteOpen(path);
+    if (kDebugMode) print('[FileLauncher] Launched via ShellExecuteW: $path ($launched)');
+    return launched;
+  }
+
   final uri = Uri.file(path);
   if (kDebugMode) print('[FileLauncher] Launching URI: $uri');
   final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -434,7 +434,7 @@ packages:
     source: hosted
     version: "1.3.3"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
@@ -1771,7 +1771,7 @@ packages:
     source: hosted
     version: "1.2.1"
   win32:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: win32
       sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,8 @@ dependencies:
   fl_chart: ^1.2.0
   windows_taskbar: ^1.1.2
   super_drag_and_drop: ^0.9.1
+  win32: ^5.15.0
+  ffi: ^2.1.4
 
 dev_dependencies:
   flutter_test:

--- a/test/utils/file_launcher_test.dart
+++ b/test/utils/file_launcher_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:daw_project_manager/utils/file_launcher_platform_macos.dart';
+
+// Regression test for https://github.com/bandpassrecords/daw-project-manager/issues/62:
+// projects with a '#' in the path failed to launch on Windows.
+//
+// Root cause: launchResolvedPath used to always build a Uri.file(path) and
+// hand it to url_launcher. url_launcher_windows unescapes %-encoded file://
+// URLs before calling ShellExecuteW (to support UTF-8 paths), which turns the
+// '%23' from Uri.file() back into a literal '#'. ShellExecuteW then reparses
+// the still "file://"-prefixed string as a URL and treats '#' as a fragment
+// delimiter, silently truncating the path there.
+//
+// The fix calls ShellExecuteW directly with the raw path (no file:// URI at
+// all) for the specific paths that trigger this — those containing '#' — and
+// leaves every other path on the existing url_launcher flow. The actual
+// ShellExecuteW call can't be exercised in a unit test (it launches a real
+// Windows process/association), so this pins the one thing that is pure and
+// matters: which paths get routed to the workaround.
+void main() {
+  group('windowsNeedsDirectShellExecute', () {
+    test('is true for a Windows path containing "#"', () {
+      expect(windowsNeedsDirectShellExecute(r'C:\Music\Project #1\song.flp'),
+          isTrue);
+    }, testOn: 'windows');
+
+    test('is false for a Windows path with no "#"', () {
+      expect(windowsNeedsDirectShellExecute(r'C:\Music\Song.flp'), isFalse);
+    }, testOn: 'windows');
+
+    test('is false on non-Windows platforms even with "#" in the path', () {
+      expect(windowsNeedsDirectShellExecute('/Music/Project #1/song.flp'),
+          isFalse);
+    }, testOn: 'mac-os || linux');
+  });
+}


### PR DESCRIPTION
url_launcher_windows unescapes %-encoded file:// URLs before calling ShellExecuteW (to support UTF-8 paths), which turns the '%23' from Uri.file() back into a literal '#'. ShellExecuteW then reparses the still-"file://"-prefixed string as a URL and treats '#' as a fragment delimiter, silently truncating the path there.

For Windows paths containing '#', call ShellExecuteW directly via the win32 package with the raw path instead — no file:// URI is built, so there's nothing to misparse. All other paths keep going through url_launcher unchanged.


Fixes #62 