### PR TITLE
Prevent the Actions column from being drag-reordered

### DIFF
--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -609,6 +609,12 @@ class SelectedProjectsNotifier extends Notifier<Set<String>> {
     current.addAll(projectIds);
     state = current;
   }
+
+  void removeAll(List<String> projectIds) {
+    final current = Set<String>.from(state);
+    current.removeAll(projectIds);
+    state = current;
+  }
 }
 
 // Recently Discovered Projects Provider — IDs of projects the background

--- a/lib/services/google_drive_sync_service.dart
+++ b/lib/services/google_drive_sync_service.dart
@@ -895,7 +895,12 @@ class GoogleDriveSyncService {
       if (refreshToken != null) {
         await _saveCredentials(refreshToken, accessTokenString, expiryTime);
       }
-      
+
+      // Other GoogleDriveSyncService instances (e.g. the tray service's) hold
+      // their own auth state — notify them so they can pick up the freshly
+      // persisted credentials via restoreSession().
+      _authStateController.add(true);
+
       if (kDebugMode) print('Authenticated client created successfully using googleapis_auth');
       return authClient;
     } catch (e, stackTrace) {
@@ -930,7 +935,8 @@ class GoogleDriveSyncService {
       }
       _driveApi = null;
       _appDataFolderId = null;
-      
+      _authStateController.add(false);
+
       if (kDebugMode) print('✓ Signed out successfully');
     } catch (e) {
       if (kDebugMode) print('Error signing out: $e');
@@ -938,7 +944,21 @@ class GoogleDriveSyncService {
       _currentUser = null;
       _isAuthenticated = false;
       _driveApi = null;
+      _authStateController.add(false);
     }
+  }
+
+  /// Clears this instance's in-memory auth state only — does not touch
+  /// persisted credentials or the auth client (which belongs to whichever
+  /// instance owns it). Used to bring a passive instance (e.g. the tray
+  /// service's) back in sync after another instance's [signOut] broadcast
+  /// on [authStateStream], without re-triggering that broadcast.
+  void forgetLocalSession() {
+    _desktopAuthClient = null;
+    _driveApi = null;
+    _currentUser = null;
+    _isAuthenticated = false;
+    _appDataFolderId = null;
   }
 
   /// Returns the credentials file path for macOS (avoids Keychain prompts).

--- a/lib/services/tray_service.dart
+++ b/lib/services/tray_service.dart
@@ -23,6 +23,7 @@ class TrayService with TrayListener {
   final GoogleDriveSyncService _syncService;
 
   bool _initialized = false;
+  StreamSubscription<bool>? _authStateSubscription;
 
   Future<void> init() async {
     if (_initialized) return;
@@ -33,6 +34,19 @@ class TrayService with TrayListener {
     // Localized labels need a BuildContext, which isn't ready until the
     // first frame — build the real menu right after that.
     WidgetsBinding.instance.addPostFrameCallback((_) => unawaited(_rebuildMenu()));
+    // The tray's GoogleDriveSyncService is a separate instance from the one
+    // the sign-in UI uses, so it doesn't see sign-in/out unless notified.
+    _authStateSubscription =
+        GoogleDriveSyncService.authStateStream.listen(_handleAuthStateChanged);
+  }
+
+  Future<void> _handleAuthStateChanged(bool signedIn) async {
+    if (signedIn && !_syncService.isSignedIn) {
+      await _syncService.restoreSession();
+    } else if (!signedIn && _syncService.isSignedIn) {
+      _syncService.forgetLocalSession();
+    }
+    await _rebuildMenu();
   }
 
   AppLocalizations? get _l10n {
@@ -139,5 +153,11 @@ class TrayService with TrayListener {
         unawaited(quitApp());
         break;
     }
+  }
+
+  Future<void> dispose() async {
+    await _authStateSubscription?.cancel();
+    _authStateSubscription = null;
+    trayManager.removeListener(this);
   }
 }

--- a/lib/ui/dashboard_page.dart
+++ b/lib/ui/dashboard_page.dart
@@ -5461,6 +5461,7 @@ class _PlutoProjectsTableState extends ConsumerState<_PlutoProjectsTable> {
         type: TrinaColumnType.text(),
         enableEditingMode: false,
         enableSorting: false,
+        enableColumnDrag: false,
         width: 290, // Increased width to accommodate all action buttons
         minWidth: 250,
         renderer: (ctx) {

--- a/lib/ui/dashboard_page.dart
+++ b/lib/ui/dashboard_page.dart
@@ -2640,6 +2640,22 @@ class _PlutoProjectsTableWithSelectionState extends ConsumerState<_PlutoProjects
         widget.projects.every((p) => _selectedProjectIds.contains(p.id));
   }
 
+  /// Selects or deselects every project inside one smart-folder group,
+  /// leaving the rest of the current selection untouched (unlike the header
+  /// "select all", which is a global select-everything/clear-everything
+  /// toggle). Lets a user pick a single group's checkbox to bulk-edit just
+  /// that folder — e.g. move every project in it to a new phase — without
+  /// first selecting everything else and without needing the group expanded.
+  void _toggleGroupSelection(Set<String> groupProjectIds) {
+    if (groupProjectIds.isEmpty) return;
+    final notifier = ref.read(selectedProjectsProvider.notifier);
+    if (groupCheckboxShouldSelect(groupProjectIds, _selectedProjectIds)) {
+      notifier.addAll(groupProjectIds.toList());
+    } else {
+      notifier.removeAll(groupProjectIds.toList());
+    }
+  }
+
   Future<void> _showChangeStatusDialog(BuildContext context) async {
     String? selectedStatus;
     
@@ -3042,6 +3058,7 @@ class _PlutoProjectsTableWithSelectionState extends ConsumerState<_PlutoProjects
             dateFormat: widget.dateFormat,
             selectedIds: _selectedProjectIds,
             onToggleSelection: _toggleProjectSelection,
+            onToggleGroupSelection: _toggleGroupSelection,
             onHideProjects: widget.onHideProjects,
             onUnhideProjects: widget.onUnhideProjects,
             areAllSelected: _areAllSelected,
@@ -3263,6 +3280,7 @@ class _PlutoProjectsTable extends ConsumerStatefulWidget {
   final DateFormat dateFormat;
   final Set<String> selectedIds;
   final Function(String) onToggleSelection;
+  final Function(Set<String>) onToggleGroupSelection;
   final Function(List<String>) onHideProjects;
   final Function(List<String>) onUnhideProjects;
   final bool areAllSelected;
@@ -3277,6 +3295,7 @@ class _PlutoProjectsTable extends ConsumerStatefulWidget {
     required this.dateFormat,
     required this.selectedIds,
     required this.onToggleSelection,
+    required this.onToggleGroupSelection,
     required this.onHideProjects,
     required this.onUnhideProjects,
     required this.areAllSelected,
@@ -3443,6 +3462,18 @@ Set<String> groupChildProjectIds(TrinaRow groupRow) {
       .map((r) => (r.cells['data']?.value as MusicProject?)?.id)
       .whereType<String>()
       .toSet();
+}
+
+/// Whether clicking a smart-folder group's own checkbox should select its
+/// members, as opposed to deselecting them. Selects unless every member of
+/// [groupProjectIds] is already in [currentlySelected] — so a partially- or
+/// un-selected group fills in the rest, and a fully-selected group clears
+/// out. Mirrors a standard "select all in this folder" checkbox rather than
+/// a plain per-item toggle, since the group checkbox represents many
+/// projects at once.
+@visibleForTesting
+bool groupCheckboxShouldSelect(Set<String> groupProjectIds, Set<String> currentlySelected) {
+  return !(groupProjectIds.isNotEmpty && groupProjectIds.every(currentlySelected.contains));
 }
 
 /// The key used to bucket a project into its smart-folder group during
@@ -5078,10 +5109,31 @@ class _PlutoProjectsTableState extends ConsumerState<_PlutoProjectsTable> {
           );
         },
         renderer: (rendererContext) {
-          final project = rendererContext.row.cells['data']?.value as MusicProject?;
+          final row = rendererContext.row;
+          final project = row.cells['data']?.value as MusicProject?;
           if (project == null) {
+            if (row.type.isGroup) {
+              // Selects/deselects every project in this smart-folder group in
+              // one click — the group may be collapsed, or only partially
+              // selected from prior individual clicks, so this reads live
+              // off the group's own children rather than any cached count.
+              final childIds = groupChildProjectIds(row);
+              final allSelected =
+                  childIds.isNotEmpty && childIds.every(widget.selectedIds.contains);
+              final anySelected = childIds.any(widget.selectedIds.contains);
+              return Transform.scale(
+                scale: 0.78,
+                child: Checkbox(
+                  value: allSelected,
+                  tristate: anySelected && !allSelected,
+                  onChanged: childIds.isEmpty
+                      ? null
+                      : (_) => widget.onToggleGroupSelection(childIds),
+                ),
+              );
+            }
             return _ExpandArrowCell(
-              row: rendererContext.row,
+              row: row,
               stateManager: rendererContext.stateManager,
             );
           }

--- a/lib/ui/releases_tab_page.dart
+++ b/lib/ui/releases_tab_page.dart
@@ -572,6 +572,7 @@ class _ReleasesTableState extends ConsumerState<_ReleasesTable> {
         title: AppLocalizations.of(context)!.actions,
         field: 'actions',
         type: TrinaColumnType.text(),
+        enableColumnDrag: false,
         width: 200,
         minWidth: 180,
         renderer: (ctx) {

--- a/test/providers/selected_projects_notifier_test.dart
+++ b/test/providers/selected_projects_notifier_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:daw_project_manager/providers/providers.dart';
+
+void main() {
+  group('SelectedProjectsNotifier', () {
+    test('defaults to an empty set', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+
+      expect(c.read(selectedProjectsProvider), isEmpty);
+    });
+
+    test('toggle adds an unselected id and removes a selected one', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final notifier = c.read(selectedProjectsProvider.notifier);
+
+      notifier.toggle('a');
+      expect(c.read(selectedProjectsProvider), {'a'});
+
+      notifier.toggle('a');
+      expect(c.read(selectedProjectsProvider), isEmpty);
+    });
+
+    test('selectAll replaces the current selection entirely', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final notifier = c.read(selectedProjectsProvider.notifier);
+
+      notifier.toggle('stale');
+      notifier.selectAll(['a', 'b']);
+
+      expect(c.read(selectedProjectsProvider), {'a', 'b'});
+    });
+
+    test('addAll merges ids into the selection without dropping existing ones', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final notifier = c.read(selectedProjectsProvider.notifier);
+
+      notifier.addAll(['a', 'b']);
+      notifier.addAll(['b', 'c']);
+
+      expect(c.read(selectedProjectsProvider), {'a', 'b', 'c'});
+    });
+
+    test('removeAll clears only the given ids, leaving unrelated selections intact', () {
+      // Regression: the per-group checkbox on a smart-folder group needs to
+      // deselect just that group's members without wiping out a selection
+      // the user made elsewhere in the table (unlike the header "select
+      // all", which is a global replace via selectAll()).
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final notifier = c.read(selectedProjectsProvider.notifier);
+
+      notifier.addAll(['a', 'b', 'unrelated']);
+      notifier.removeAll(['a', 'b']);
+
+      expect(c.read(selectedProjectsProvider), {'unrelated'});
+    });
+
+    test('removeAll silently ignores ids that were never selected', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final notifier = c.read(selectedProjectsProvider.notifier);
+
+      notifier.addAll(['a']);
+      notifier.removeAll(['a', 'does-not-exist']);
+
+      expect(c.read(selectedProjectsProvider), isEmpty);
+    });
+
+    test('clear empties the selection', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final notifier = c.read(selectedProjectsProvider.notifier);
+
+      notifier.addAll(['a', 'b']);
+      notifier.clear();
+
+      expect(c.read(selectedProjectsProvider), isEmpty);
+    });
+  });
+}

--- a/test/services/google_drive_sync_service_test.dart
+++ b/test/services/google_drive_sync_service_test.dart
@@ -63,6 +63,50 @@ void main() {
     });
   });
 
+  group('GoogleDriveSyncService cross-instance auth sync', () {
+    // Regression: the app creates a separate GoogleDriveSyncService instance
+    // per consumer (e.g. one for the tray, one for the sign-in page). Auth
+    // state lives on instance fields, so signing in on one instance left
+    // every other instance's isSignedIn stuck at false (tray "Backup Now"
+    // menu item stayed disabled) until app restart. authStateStream +
+    // forgetLocalSession() let a passive instance reconcile.
+
+    test('forgetLocalSession clears in-memory auth state without touching other instances', () {
+      final signedInInstance = GoogleDriveSyncService();
+      signedInInstance.desktopAuthClient = _FakeAuthClient();
+      signedInInstance.driveApi = drive.DriveApi(http.Client());
+      expect(signedInInstance.isSignedIn, isTrue);
+
+      final passiveInstance = GoogleDriveSyncService();
+      passiveInstance.desktopAuthClient = _FakeAuthClient();
+      passiveInstance.driveApi = drive.DriveApi(http.Client());
+      expect(passiveInstance.isSignedIn, isTrue);
+
+      passiveInstance.forgetLocalSession();
+
+      expect(passiveInstance.isSignedIn, isFalse);
+      expect(signedInInstance.isSignedIn, isTrue,
+          reason: 'clearing one instance must not affect another');
+    });
+
+    test('signOut broadcasts false on the shared authStateStream', () async {
+      final service = GoogleDriveSyncService();
+      service.desktopAuthClient = _FakeAuthClient();
+      service.driveApi = drive.DriveApi(http.Client());
+
+      final events = <bool>[];
+      final sub = GoogleDriveSyncService.authStateStream.listen(events.add);
+
+      await service.signOut();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, contains(false));
+      expect(service.isSignedIn, isFalse);
+
+      await sub.cancel();
+    });
+  });
+
   group('GoogleDriveSyncService.mergeData - custom mixdown folders and phase settings', () {
     late Directory tempDir;
     late ProjectRepository projectRepo;

--- a/test/ui/dashboard_page_test.dart
+++ b/test/ui/dashboard_page_test.dart
@@ -305,6 +305,34 @@ void main() {
     });
   });
 
+  group('groupCheckboxShouldSelect', () {
+    // Backs the checkbox on a smart-folder group's own header row: clicking
+    // it should select every project in that group in one go (a
+    // collapsed group can be bulk-edited without expanding it first), and
+    // clicking an already-fully-selected group should clear just that group.
+
+    test('selects when none of the group is selected', () {
+      expect(groupCheckboxShouldSelect({'a', 'b'}, {}), isTrue);
+    });
+
+    test('selects (fills in the rest) when the group is only partially selected', () {
+      expect(groupCheckboxShouldSelect({'a', 'b'}, {'a'}), isTrue);
+    });
+
+    test('deselects when every member of the group is already selected', () {
+      expect(groupCheckboxShouldSelect({'a', 'b'}, {'a', 'b'}), isFalse);
+    });
+
+    test('is unaffected by selections outside the group', () {
+      expect(groupCheckboxShouldSelect({'a', 'b'}, {'a', 'b', 'unrelated'}), isFalse);
+      expect(groupCheckboxShouldSelect({'a', 'b'}, {'unrelated'}), isTrue);
+    });
+
+    test('an empty group has nothing to fully select, so it reports select', () {
+      expect(groupCheckboxShouldSelect({}, {}), isTrue);
+    });
+  });
+
   group('expandedGroupNames / groupRowsToExpand', () {
     // Regression coverage for: switching theme or language collapsed every
     // smart folder. TrinaGrid's key includes locale + theme, so either


### PR DESCRIPTION
The trailing action-buttons column should stay pinned in place; other columns remain freely reorderable.